### PR TITLE
More resilient HTTP processing

### DIFF
--- a/lib/core/http-buffer.ts
+++ b/lib/core/http-buffer.ts
@@ -64,7 +64,6 @@ export class HTTPBuffer {
                     let length = this._rawBody.length;
                     if (this.hasHeader("Content-Length")) {
                         length = parseInt(this.header("Content-Length"));
-
                     }
 
                     this._complete = this._rawBody.length === length;

--- a/lib/server/webhook-manager.ts
+++ b/lib/server/webhook-manager.ts
@@ -2,7 +2,6 @@ import {WebhookRequest} from "../core/webhook-request";
 import * as net from "net";
 import {Server} from "net";
 import {Socket} from "net";
-import {BufferUtil} from "../core/buffer-util";
 import {LoggingHelper} from "../core/logging-helper";
 
 let Logger = "WEBHOOK";


### PR DESCRIPTION
Make sure Transfer-Encoding header is set to chunked
Just pass-thru payloads without a content-length (without treating them as chunked)