### PR TITLE
commander fixes

### DIFF
--- a/bin/bst-deploy.ts
+++ b/bin/bst-deploy.ts
@@ -19,16 +19,21 @@ program
     .option("--verbose", "Print out verbose diagnostics")
     .description("Deploys a AWS Lambda defined in the specified folder")
     .action(function (lambdaFolder: string, options: any) {
-
         if (options.verbose !== undefined && options.verbose) {
             console.log("Enabling verbose logging");
             LoggingHelper.setVerbose(true);
         }
 
-        let isDir = fs.lstatSync(lambdaFolder).isDirectory();
+        let isDir: boolean = false;
+
+        try {
+            isDir = fs.lstatSync(lambdaFolder).isDirectory();
+        } catch (e) {
+            // oops
+        }
 
         if (!isDir) {
-            console.error(lambdaFolder + " is not a folder! You need to specify the project folder!");
+            console.error("  error: " + lambdaFolder + " is not a folder! You need to specify the lambda project folder!");
             console.error("");
             process.exit(1);
             return;
@@ -40,7 +45,7 @@ program
             lambdaConfig.initialize();
             lambdaConfig.validate();
         } catch (err) {
-            console.error("Parameter validation error: " + err);
+            console.error("error: parameter validation error: " + err);
             console.error("");
             process.exit(1);
             return;
@@ -123,7 +128,19 @@ program
 
 if (process.argv.length < 3) {
     program.outputHelp();
+    process.exit();
 }
+
+if (["lambda"].indexOf(process.argv[2]) < 0) {
+    console.error("  error: unknown command: " + process.argv[2] + "\n");
+    process.exit();
+}
+
+program.Command.prototype.missingArgument = function(name: string): void {
+    console.error("  error: missing required argument " + name);
+    console.error();
+    process.exit(1);
+};
 
 program.parse(process.argv);
 

--- a/bin/bst-proxy.ts
+++ b/bin/bst-proxy.ts
@@ -85,7 +85,19 @@ program
 // Forces help to be printed if neither lambda nor HTTP is printed
 if (process.argv.length < 3) {
     program.outputHelp();
+    process.exit();
 }
+
+if (["http", "lambda", "stop", "urlgen"].indexOf(process.argv[2]) < 0) {
+    console.error("  error: unknown command: " + process.argv[2] + "\n");
+    process.exit();
+}
+
+program.Command.prototype.missingArgument = function(name: string): void {
+    console.error("  error: missing required argument " + name);
+    console.error();
+    process.exit(1);
+};
 
 program.parse(process.argv);
 

--- a/bin/bst.ts
+++ b/bin/bst.ts
@@ -22,7 +22,7 @@ program
     .command("intend <intent> [SlotName=SlotValue...]", "Sends the specified intent to your service")
     .command("speak <utterance>", "Sends an intent with the specified utterance to your service")
     .command("sleep <location>", "Instructs bst to sleep using specified location")
-    .command("deploy <lambda>", "Deploys a skill");
+    .command("deploy <lambda>", "Deploys a lambda");
 
 program.parse(process.argv);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,19 +14,7 @@ gulp.task('build', ['setup', 'lint'], function () {
 // http://stackoverflow.com/questions/33191377/gulp-hangs-after-finishing
 gulp.task('test', ['build'], function() {
     return gulp.src(['test/**/*-test.js'])
-        .pipe(mocha())
-        .on('error', () => {
-            console.log("Yeepee! Tests error!");
-            process.exit(1);
-        })
-        .on('stop', () => {
-            console.log("Yeepee! Tests stop!");
-            process.exit();
-        })
-        .on('end', () => {
-            console.log("Yeepee! Tests end!");
-            process.exit();
-        });
+        .pipe(mocha());
 });
 
 gulp.task('setup', function (done) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,11 +15,16 @@ gulp.task('build', ['setup', 'lint'], function () {
 gulp.task('test', ['build'], function() {
     return gulp.src(['test/**/*-test.js'])
         .pipe(mocha())
-        .once('error', () => {
+        .on('error', () => {
+            console.log("Yeepee! Tests error!");
             process.exit(1);
         })
-        .once('end', () => {
-            console.log("Yeepee! Tests ended!");
+        .on('stop', () => {
+            console.log("Yeepee! Tests stop!");
+            process.exit();
+        })
+        .on('end', () => {
+            console.log("Yeepee! Tests end!");
             process.exit();
         });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ gulp.task('build', ['setup', 'lint'], function () {
     return run('node_modules/typescript/bin/tsc').exec();
 });
 
+// http://stackoverflow.com/questions/33191377/gulp-hangs-after-finishing
 gulp.task('test', ['build'], function() {
     return gulp.src(['test/**/*-test.js'])
         .pipe(mocha())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,13 @@ gulp.task('build', ['setup', 'lint'], function () {
 
 gulp.task('test', ['build'], function() {
     return gulp.src(['test/**/*-test.js'])
-        .pipe(mocha());
+        .pipe(mocha())
+        .once('error', () => {
+            process.exit(1);
+        })
+        .once('end', () => {
+            process.exit();
+        });
 });
 
 gulp.task('setup', function (done) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,20 +7,16 @@ const typedoc = require('gulp-bst-typedoc');
 const run = require('gulp-run');
 const shell = require('gulp-shell');
 
+gulp.on('stop', () => { process.exit(0); });
+gulp.on('err', () => { process.exit(1); });
+
 gulp.task('build', ['setup', 'lint'], function () {
     return run('node_modules/typescript/bin/tsc').exec();
 });
 
-// http://stackoverflow.com/questions/33191377/gulp-hangs-after-finishing
 gulp.task('test', ['build'], function() {
     return gulp.src(['test/**/*-test.js'])
-        .pipe(mocha())
-        .once('error', () => {
-            process.exit(1);
-        })
-        .once('end', () => {
-            process.exit();
-        });
+        .pipe(mocha());
 });
 
 gulp.task('setup', function (done) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,16 +7,21 @@ const typedoc = require('gulp-bst-typedoc');
 const run = require('gulp-run');
 const shell = require('gulp-shell');
 
-gulp.on('stop', () => { process.exit(0); });
-gulp.on('err', () => { process.exit(1); });
-
 gulp.task('build', ['setup', 'lint'], function () {
     return run('node_modules/typescript/bin/tsc').exec();
 });
 
+// http://stackoverflow.com/questions/33191377/gulp-hangs-after-finishing
 gulp.task('test', ['build'], function() {
     return gulp.src(['test/**/*-test.js'])
-        .pipe(mocha());
+        .pipe(mocha())
+        .once('error', () => {
+            process.exit(1);
+        })
+        .once('end', () => {
+            console.log("Yeepee! Tests ended!");
+            process.exit();
+        });
 });
 
 gulp.task('setup', function (done) {

--- a/test/bin/bst-deploy-test.ts
+++ b/test/bin/bst-deploy-test.ts
@@ -61,6 +61,7 @@ describe("bst-deploy", function() {
         mockery.registerMock("../lib/client/lambda-deploy", mockDeployModule);
         mockery.registerMock("../lib/client/lambda-role", mockRoleModule);
         sandbox = sinon.sandbox.create();
+        sandbox.stub(process, "exit", function () {}); // Ignore exit()
         process.chdir("test/resources");
     });
 
@@ -78,7 +79,6 @@ describe("bst-deploy", function() {
         });
 
         afterEach (function () {
-            process.stdout.write = originalFunction;
         });
 
         it("Prints help with no-args", function(done) {
@@ -96,8 +96,9 @@ describe("bst-deploy", function() {
             };
 
             // Wait for all - maybe more than one message
-
             setTimeout(() => {
+                process.stdout.write = originalFunction;
+
                 if (dataString.indexOf("Usage") !== -1) {
                     done();
                 } else {
@@ -109,8 +110,8 @@ describe("bst-deploy", function() {
         });
     });
 
-    describe("lambda command", function() {
-        it("with no options", function(done) {
+    describe("Lambda command", function() {
+        it("No options", function(done) {
             this.timeout(5000);
 
             process.argv = command("node bst-deploy.js lambda " + deployProject);
@@ -122,7 +123,7 @@ describe("bst-deploy", function() {
             NodeUtil.load("../../bin/bst-deploy.js");
         });
 
-        it("with options", function(done) {
+        it("Options", function(done) {
             this.timeout(5000);
 
             process.argv = command("node bst-deploy.js lambda " + deployProject + " --verbose --lambdaName " + testLambdaName);
@@ -137,6 +138,8 @@ describe("bst-deploy", function() {
             let optionsSet = false;
 
             mockDeploy.deploy = function () {
+                sandbox.restore();
+
                 optionsSet = mockDeploy.lambdaConfig.AWS_FUNCTION_NAME === testLambdaName;
 
                 if (!verboseCalled) {
@@ -151,7 +154,6 @@ describe("bst-deploy", function() {
             NodeUtil.load("../../bin/bst-deploy.js");
         });
     });
-
 });
 
 let command = function (command: string): Array<string> {

--- a/test/bin/bst-invalid-test.ts
+++ b/test/bin/bst-invalid-test.ts
@@ -9,8 +9,8 @@ describe("bst commands", function() {
     let sandbox: SinonSandbox = null;
     let originalFunction: any = null;
     let dataString: string = "";
-    let resultPattern:string = "";
-    let mochaDone:MochaDone = null;
+    let resultPattern: string = "";
+    let mochaDone: MochaDone = null;
 
     let collectError = function (buffer: Buffer|string) {
         if (buffer instanceof Buffer) {
@@ -28,7 +28,7 @@ describe("bst commands", function() {
         } else {
             mochaDone(new Error(resultPattern + " was not in the output!"));
         }
-    }
+    };
 
     beforeEach(function () {
         mockery.enable({useCleanCache: true});

--- a/test/bin/bst-invalid-test.ts
+++ b/test/bin/bst-invalid-test.ts
@@ -1,0 +1,105 @@
+/// <reference path="../../typings/index.d.ts" />
+
+import * as mockery from "mockery";
+import * as sinon from "sinon";
+import {NodeUtil} from "../../lib/core/node-util";
+import SinonSandbox = Sinon.SinonSandbox;
+
+describe("bst commands", function() {
+    let sandbox: SinonSandbox = null;
+    let originalFunction: any = null;
+    let dataString: string = "";
+    let resultPattern:string = "";
+    let mochaDone:MochaDone = null;
+
+    let collectError = function (buffer: Buffer|string) {
+        if (buffer instanceof Buffer) {
+            dataString = dataString + buffer.toString();
+        } else {
+            dataString = dataString + buffer;
+        }
+    };
+
+    let checkResult = function() {
+        process.stdout.write = originalFunction;
+
+        if (dataString.indexOf(resultPattern) !== -1) {
+            mochaDone();
+        } else {
+            mochaDone(new Error(resultPattern + " was not in the output!"));
+        }
+    }
+
+    beforeEach(function () {
+        mockery.enable({useCleanCache: true});
+        mockery.warnOnUnregistered(false);
+        sandbox = sinon.sandbox.create();
+        sandbox.stub(process, "exit", function (n: number) {}); // Ignore exit()
+        originalFunction = process.stdout.write;
+        dataString = "";
+        (<any> process.stderr).write = collectError;
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    this.timeout(2000);
+
+    describe("Invalid deploy command", function() {
+        it("Prints error with invalid command", function(done) {
+            process.argv = command("node bst-deploy.js foo");
+            resultPattern = "unknown command";
+            mochaDone = done;
+            setTimeout(checkResult, 1000);
+            NodeUtil.load("../../bin/bst-deploy.js");
+        });
+
+        it("Prints error with missing mandatory arg", function(done) {
+            process.argv = command("node bst-deploy.js lambda");
+            resultPattern = "missing required argument lambda-folder";
+            mochaDone = done;
+            setTimeout(checkResult, 1000);
+            NodeUtil.load("../../bin/bst-deploy.js");
+        });
+    });
+
+    describe("Invalid proxy command", function() {
+        beforeEach(function () {
+            let mockProxy: any = {
+                BSTProxy: {
+                    lambda: function () {
+                        return this;
+                    },
+                    start: function () {
+                        return this;
+                    }
+                }
+            };
+
+            mockery.registerMock("../lib/client/bst-proxy", mockProxy);
+        });
+
+        it("Prints error with invalid command", function(done) {
+            process.argv = command("node bst-proxy.js foo");
+            resultPattern = "unknown command";
+            mochaDone = done;
+            setTimeout(checkResult, 1000);
+            NodeUtil.load("../../bin/bst-proxy.js");
+        });
+
+        it("Prints error with missing mandatory arg", function(done) {
+            process.argv = command("node bst-proxy.js lambda");
+            resultPattern = "missing required argument lambda-file";
+            mochaDone = done;
+            setTimeout(checkResult, 1000);
+            NodeUtil.load("../../bin/bst-proxy.js");
+        });
+    });
+});
+
+let command = function (command: string): Array<string> {
+    return command.split(" ");
+};

--- a/test/bin/bst-proxy-test.ts
+++ b/test/bin/bst-proxy-test.ts
@@ -30,6 +30,7 @@ describe("bst-proxy", function() {
         mockery.warnOnUnregistered(false);
         mockery.registerMock("../lib/client/bst-proxy", mockModule);
         sandbox = sinon.sandbox.create();
+        sandbox.stub(process, "exit", function () {}); // Ignore exit()
     });
 
     afterEach(function () {

--- a/test/bin/bst-sleep-test.ts
+++ b/test/bin/bst-sleep-test.ts
@@ -10,6 +10,7 @@ describe("bst-sleep", function() {
         // Picks up lint on re-runs - dump it every time
         delete require.cache[require.resolve("commander")];
         sandbox = sinon.sandbox.create();
+        sandbox.stub(process, "exit", function () {}); // Ignore exit()
     });
 
     afterEach(function () {

--- a/test/client/bst-deploy-test.ts
+++ b/test/client/bst-deploy-test.ts
@@ -190,7 +190,7 @@ describe("LambdaDeploy", function() {
             // We can put this in the callback (then) of the delete above, but the problem is the propagation time
 
             setTimeout(() => {
-                console.log("Waited 2 seconds for AWS after delete");
+                console.log("Waited a few seconds for AWS after delete");
                 awsHelper.createRole(testAwsRole)
                     .then((arn: string) => {
                         console.log("Created role: " + arn);
@@ -205,7 +205,6 @@ describe("LambdaDeploy", function() {
         });
 
         it("creates invalid role", function (done) {
-            console.log("Waited 2 seconds for AWS after delete");
             awsHelper.createRole("#$%^&*_i_hope_invalid")
                 .then((arn: string) => {
                     console.error("Created role: " + arn);
@@ -219,15 +218,18 @@ describe("LambdaDeploy", function() {
         });
 
         it("finds a role", function(done) {
-            awsHelper.getRole(testAwsRole)
-                .then((arn: string) => {
-                    console.log("Role was found");
-                    done();
-                })
-                .catch((err) => {
-                    console.error("Error finding AWS role: " + err);
-                    done(err);
-                });
+            setTimeout(() => {
+                console.log("Waited a few seconds for AWS before role lookup");
+                awsHelper.getRole(testAwsRole)
+                    .then((arn: string) => {
+                        console.log("Role was found: " + arn);
+                        done();
+                    })
+                    .catch((err) => {
+                        console.error("Error finding AWS role: " + err);
+                        done(err);
+                    });
+                }, 2000);
         });
 
         it("finds nonexistent role", function(done) {
@@ -314,6 +316,7 @@ describe("LambdaDeploy", function() {
 
             LoggingHelper.setVerbose(true);
 
+            console.log("Waited a few seconds for AWS before function deploy");
             setTimeout(() => {
                 deployer.deploy(function(error: Error) {
                     if (error) {


### PR DESCRIPTION
I ran a couple of laps. This is the best I can do for the invalid parameters. 

Commander is buggy:
1. The  error _missing required argument `%s'_ message comes because the console.error doesn't take the %s placeholder (same in node 6.3 and 4.3). So I overrode the prototype function.
2. If the command is invalid Commander just silently quits. I tried the "_" command. It works as a catch-all, but prints out the "_" in the usage help. Silly. So I went low tech. I only did it in deploy and proxy. 
