### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/alexa/alexa-context.ts
+++ b/lib/alexa/alexa-context.ts
@@ -1,7 +1,7 @@
 import {AudioPlayer} from "./audio-player";
 import {InteractionModel} from "./interaction-model";
 import {AlexaSession} from "./alexa-session";
-const uuid = require("node-uuid");
+const uuid = require("uuid");
 
 export class AlexaContext {
     private _userID: string;

--- a/lib/alexa/alexa-session.ts
+++ b/lib/alexa/alexa-session.ts
@@ -1,4 +1,4 @@
-const uuid = require("node-uuid");
+const uuid = require("uuid");
 
 export class AlexaSession {
     private _attributes: {[id: string]: any};

--- a/lib/alexa/service-request.ts
+++ b/lib/alexa/service-request.ts
@@ -1,6 +1,6 @@
 import {AlexaContext} from "./alexa-context";
 import {AudioPlayerActivity} from "./audio-player";
-const uuid = require("node-uuid");
+const uuid = require("uuid");
 
 export class RequestType {
     public static IntentRequest = "IntentRequest";

--- a/lib/client/bst-config.ts
+++ b/lib/client/bst-config.ts
@@ -3,7 +3,7 @@ import {ProxyType} from "./bst-proxy";
 import {LoggingHelper} from "../core/logging-helper";
 import {LambdaConfig} from "./lambda-config";
 
-let uuid = require("node-uuid");
+let uuid = require("uuid");
 
 const Logger = "CONFIG";
 const BSTDirectoryName = ".bst";

--- a/lib/logless/logless-context.ts
+++ b/lib/logless/logless-context.ts
@@ -1,7 +1,7 @@
 import * as https from "https";
 import * as util from "util";
 import {Logless} from "./logless";
-const uuid = require("node-uuid");
+const uuid = require("uuid");
 
 export class LoglessContext {
     private _callback: Function;

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "aws-sdk": "^2.6.8",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
-    "node-uuid": "1.4.7",
     "node-zip": "^1.1.1",
     "properties-reader": "0.0.15",
     "request": "^2.74.0",
     "sinon": "^1.17.5",
     "typescript": "^1.8.10",
+    "uuid": "^3.0.0",
     "winston": "^2.2.0",
     "wrench": "^1.5.9"
   },

--- a/test/server/statistics-test.ts
+++ b/test/server/statistics-test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import {Statistics, AccessType} from "../../lib/server/statistics";
-const uuid = require("node-uuid");
+const uuid = require("uuid");
 
 const awsAccessKeyId = process.env["AWS_ACCESS_KEY_ID"];
 const awsSecretAccessKey = process.env["AWS_SECRET_ACCESS_KEY"];


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.