### PR TITLE
Return errors on speak and intend commands#226

### DIFF
--- a/bin/bst-intend.ts
+++ b/bin/bst-intend.ts
@@ -77,6 +77,12 @@ program
 
             try {
                 speaker.intended(intentName, slots, function(error: any, response: any, request: any) {
+                    if (error !== undefined && error !== null) {
+                        console.log("Intended: " + intentName);
+                        console.log("");
+                        console.log("Error: " + error.message);
+                        return;
+                    }
                     let jsonPretty = JSON.stringify(response, null, 4);
                     console.log("Intended: " + intentName);
                     console.log("");

--- a/bin/bst-intend.ts
+++ b/bin/bst-intend.ts
@@ -77,7 +77,7 @@ program
 
             try {
                 speaker.intended(intentName, slots, function(error: any, response: any, request: any) {
-                    if (error !== undefined && error !== null) {
+                    if (error) {
                         console.log("Intended: " + intentName);
                         console.log("");
                         console.log("Error: " + error.message);

--- a/bin/bst-speak.ts
+++ b/bin/bst-speak.ts
@@ -71,7 +71,7 @@ program
             }
 
             speaker.spoken(utterance, function(error: any, response: any, request: any) {
-                if (error !== undefined && error !== null) {
+                if (error) {
                     console.log("Spoke: " + utterance);
                     console.log("");
                     console.log("Error: " + error.message);

--- a/bin/bst-speak.ts
+++ b/bin/bst-speak.ts
@@ -71,6 +71,12 @@ program
             }
 
             speaker.spoken(utterance, function(error: any, response: any, request: any) {
+                if (error !== undefined && error !== null) {
+                    console.log("Spoke: " + utterance);
+                    console.log("");
+                    console.log("Error: " + error.message);
+                    return;
+                }
                 let jsonPretty = JSON.stringify(response, null, 4);
                 console.log("Spoke: " + utterance);
                 console.log("");


### PR DESCRIPTION
On Errors the application will now show errors like this:

> $bst speak next
> BST: v0.9.32  Node: v6.10.1
> 
> INFO  2017-04-04T18:01:23.442Z Intent generatednext
> Intent: Next Session: [object Object]
> Spoke: next
> 
> Error: Interaction model has no intentName named: Next