### PR TITLE
Add offline mode for Global

### DIFF
--- a/bin/bst-launch.ts
+++ b/bin/bst-launch.ts
@@ -18,6 +18,12 @@ program
         let url = options.url;
         const applicationID = options.appId;
 
+        if (process.argv.some( arg => arg === "-h" || arg === "--help")) {
+            program.outputHelp();
+            process.exit(0);
+            return;
+        }
+
         if (!options.url) {
             const proxyProcess = Global.running();
             if (proxyProcess === null) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ gulp.task('setup', function (done) {
 });
 
 gulp.task('lint', function() {
-    return gulp.src(["lib/**/*.ts", "bin/*.ts", "test/**/*.ts", "!lib/**/*.d.ts", "!bin/*.d.ts"])
+    return gulp.src(["lib/**/*.ts", "bin/*.ts", "test/**/*.ts", "!lib/**/*.d.ts", "!bin/*.d.ts", "!test/**/*.d.ts"])
         .pipe(tslint({
             formatter: "verbose"
         }))

--- a/test/bin/bst-deploy-test.ts
+++ b/test/bin/bst-deploy-test.ts
@@ -24,7 +24,7 @@ describe("bst-deploy", function() {
     let lambdaConfig = null;
     let skip: boolean = false;
 
-    before(async function (): Promise<void> {
+    before(function () {
         this.timeout(20000);
 
         Global.initialize(false, true);

--- a/test/bin/bst-deploy-test.ts
+++ b/test/bin/bst-deploy-test.ts
@@ -9,7 +9,6 @@ import {LambdaConfig} from "../../lib/client/lambda-config";
 import {Global} from "../../lib/core/global";
 
 const dotenv = require("dotenv");
-const uuid = require("uuid");
 
 // The test project
 const deployProject: string = "./deployProject";
@@ -27,15 +26,8 @@ describe("bst-deploy", function() {
 
     before(async function (): Promise<void> {
         this.timeout(20000);
-        mockery.enable({useCleanCache: true});
-        mockery.warnOnUnregistered(false);
-        mockery.warnOnReplace(false);
-        mockery.registerMock("../external/source-name-generator", {
-            SourceNameGenerator: mockSourceGenerator,
-        });
 
-        Global.initialize(false);
-        await Global.loadConfig();
+        Global.initialize(false, true);
 
         lambdaConfig = LambdaConfig.create();
         lambdaConfig.initialize();
@@ -177,16 +169,4 @@ describe("bst-deploy", function() {
 
 const command = function (command: string): Array<string> {
     return command.split(" ");
-};
-
-const mockSourceGenerator = class SourceNameGenerator {
-    public callService() {
-        const id = uuid.v4();
-        return {
-            id,
-            secretKey: "unit-test" + id,
-        };
-    };
-
-    public createDashboardSource () {};
 };

--- a/test/bin/bst-launch-test.ts
+++ b/test/bin/bst-launch-test.ts
@@ -44,6 +44,28 @@ describe("bst-launch", function() {
     });
 
     describe("Launch command", function() {
+        it("Prints help with help parameter", function(done) {
+            process.argv = command("node bst-launch.js -h");
+
+            const mockProgram = sandbox.mock(require("commander"));
+            mockProgram.expects("outputHelp").once();
+
+            const mockProcess = sandbox.mock(process);
+            mockProcess.expects("exit").once().withExactArgs(0);
+
+            NodeUtil.load("../../bin/bst-launch.js");
+
+            setTimeout(function () {
+                try {
+                    mockProgram.verify();
+                    mockProcess.verify();
+                    done();
+                } catch (assertionError) {
+                    done(assertionError);
+                }
+            }, 100);
+        });
+
         it("Prints error if launch throws error", function(done) {
             process.argv = command("node bst-launch.js");
             mockery.registerMock("../lib/client/bst-alexa", {

--- a/test/bin/bst-speak-test.ts
+++ b/test/bin/bst-speak-test.ts
@@ -200,9 +200,7 @@ describe("bst-speak", function() {
             NodeUtil.load("../../bin/bst-speak.js");
         });
 
-        // Skipping for now, it was using bst-alexa directly (which was not getting the intended result)
-        // It should mock bst-alexa to send a Interaction Model missing error.
-        /* it("Has no interaction model", function(done) {
+        it("Has no interaction model", function(done) {
             process.argv = command("node bst-speak.js Hello There Ladies And Gentlemen");
 
             sandbox.stub(process, "exit", function(exitCode: number) {
@@ -219,7 +217,7 @@ describe("bst-speak", function() {
             });
 
             NodeUtil.load("../../bin/bst-speak.js");
-        }); */
+        });
 
         it("Has No Process", function(done) {
             sandbox.stub(process, "exit", function(exitCode: number) {

--- a/test/client/bst-alexa-test.ts
+++ b/test/client/bst-alexa-test.ts
@@ -20,25 +20,16 @@ describe("BSTAlexa Without Config", function() {
     });
 });
 
-describe("BSTAlexa", async function() {
+describe("BSTAlexa", function() {
     let alexa: BSTAlexa = null;
     let lambdaServer: LambdaServer = null;
-
-    before(async function () {
-        Global.initialize(false);
-        await Global.loadConfig();
-    });
 
     describe("#start()", function () {
         let sandbox: any = null;
 
-        before(async function () {
-            Global.initialize(false);
-            await Global.loadConfig();
-        });
-
         beforeEach(function () {
             sandbox = sinon.sandbox.create();
+            Global.initialize(false, true);
         });
 
         afterEach(function () {
@@ -67,6 +58,7 @@ describe("BSTAlexa", async function() {
 
         it("Initializes with application ID", function (done) {
             this.timeout(5000);
+            console.log(Global.config());
             let speak = new BSTAlexa("http://localhost:9000",
                 "test/resources/speechAssets/IntentSchema.json",
                 "test/resources/speechAssets/SampleUtterances.txt",
@@ -79,11 +71,12 @@ describe("BSTAlexa", async function() {
 
         it("Initializing after setting the application ID initialize with application ID", function (done) {
             this.timeout(5000);
+            // Adding the applicationId to the global config before initializing alexa
+            Global.config().updateApplicationID("1234567890J");
             let speak = new BSTAlexa("http://localhost:9000",
                 "test/resources/speechAssets/IntentSchema.json",
                 "test/resources/speechAssets/SampleUtterances.txt");
             speak.start(function () {
-                assert(Global.config().applicationID(), "1234567890J");
                 assert(speak.context().applicationID(), "1234567890J");
                 done();
             });

--- a/test/client/bst-alexa-test.ts
+++ b/test/client/bst-alexa-test.ts
@@ -6,23 +6,23 @@ import {LambdaServer} from "../../lib/client/lambda-server";
 import {Global} from "../../lib/core/global";
 import * as sinon from "sinon";
 
-describe("BSTAlexa Without Config", function() {
-    it("#start()", function (done) {
-        let speak = new BSTAlexa("http://localhost:9000",
-            "test/resources/speechAssets/IntentSchema.json",
-            "test/resources/speechAssets/SampleUtterances.txt");
-        speak.start(function (error: string) {
-            assert(error === undefined);
-            speak.stop(function() {
-                done();
+describe("BSTAlexa", async function() {
+    let alexa: BSTAlexa = null;
+    let lambdaServer: LambdaServer = null;
+
+    describe("BSTAlexa Without Config", function() {
+        it("#start()", function (done) {
+            let speak = new BSTAlexa("http://localhost:9000",
+                "test/resources/speechAssets/IntentSchema.json",
+                "test/resources/speechAssets/SampleUtterances.txt");
+            speak.start(function (error: string) {
+                assert(error === undefined);
+                speak.stop(function() {
+                    done();
+                });
             });
         });
     });
-});
-
-describe("BSTAlexa", function() {
-    let alexa: BSTAlexa = null;
-    let lambdaServer: LambdaServer = null;
 
     describe("#start()", function () {
         let sandbox: any = null;
@@ -58,7 +58,6 @@ describe("BSTAlexa", function() {
 
         it("Initializes with application ID", function (done) {
             this.timeout(5000);
-            console.log(Global.config());
             let speak = new BSTAlexa("http://localhost:9000",
                 "test/resources/speechAssets/IntentSchema.json",
                 "test/resources/speechAssets/SampleUtterances.txt",
@@ -274,8 +273,9 @@ describe("BSTAlexa", function() {
             alexa = new BSTAlexa("http://localhost:10000");
             alexa.start(function () {
                 lambdaServer = new LambdaServer("AudioPlayerLambda.js", 10000);
-                lambdaServer.start();
-                done();
+                lambdaServer.start(function () {
+                    done();
+                });
             });
         });
 
@@ -293,8 +293,13 @@ describe("BSTAlexa", function() {
                 let i = 0;
                 alexa.on("AudioPlayer.PlaybackStarted", function (audioItem: any) {
                     i++;
-                    assert.equal(audioItem.stream.token, i + "");
-                    assert.equal(audioItem.stream.offsetInMilliseconds, 0);
+                    try {
+                        assert.equal(audioItem.stream.token, i + "");
+                        assert.equal(audioItem.stream.offsetInMilliseconds, 0);
+                    } catch (error) {
+                        done(error);
+                    }
+
 
                     alexa.playbackOffset(i * 1000);
                     alexa.playbackFinished();
@@ -303,8 +308,13 @@ describe("BSTAlexa", function() {
                 let j = 0;
                 alexa.on("AudioPlayer.PlaybackFinished", function (audioItem: any) {
                     j++;
-                    assert.equal(audioItem.stream.token, j + "");
-                    assert.equal(audioItem.stream.offsetInMilliseconds, j * 1000);
+                    try {
+                        assert.equal(audioItem.stream.token, j + "");
+                        assert.equal(audioItem.stream.offsetInMilliseconds, j * 1000);
+                    } catch (error) {
+                        done(error);
+                    }
+
                     if (j === 2) {
                         done();
                     }
@@ -319,9 +329,12 @@ describe("BSTAlexa", function() {
                 let i = 0;
                 alexa.once("AudioPlayer.PlaybackStarted", function (audioItem: any) {
                     i++;
-                    assert.equal(audioItem.stream.token, i + "");
-                    assert.equal(audioItem.stream.offsetInMilliseconds, 0);
-
+                    try {
+                        assert.equal(audioItem.stream.token, i + "");
+                        assert.equal(audioItem.stream.offsetInMilliseconds, 0);
+                    } catch (error) {
+                        done(error);
+                    }
                     alexa.playbackOffset(i * 1000);
                     alexa.playbackFinished();
                     alexa.once("AudioPlayer.PlaybackFinished", function () {
@@ -329,17 +342,21 @@ describe("BSTAlexa", function() {
                     });
 
                     if (i > 1) {
-                        assert.fail();
+                        done(assert.fail());
                     }
                 });
 
                 let j = 0;
                 alexa.once("AudioPlayer.PlaybackFinished", function (audioItem: any) {
                     j++;
-                    assert.equal(audioItem.stream.token, j + "");
-                    assert.equal(audioItem.stream.offsetInMilliseconds, j * 1000);
+                    try {
+                        assert.equal(audioItem.stream.token, j + "");
+                        assert.equal(audioItem.stream.offsetInMilliseconds, j * 1000);
+                    } catch (error) {
+                        done(error);
+                    }
                     if (j > 1) {
-                        assert.fail();
+                        done(assert.fail());
                     }
                 });
 
@@ -351,20 +368,28 @@ describe("BSTAlexa", function() {
             it("Audio Item Finished", function (done) {
                let count = 0;
                 alexa.on("response", function (response: any, request: any) {
-                    count++;
-                    if (count === 5) {
-                        assert.equal(request.request.type, "AudioPlayer.PlaybackFinished");
-                    }
+                    try {
+                        count++;
+                        if (count === 5) {
+                            assert.equal(request.request.type, "AudioPlayer.PlaybackFinished");
+                        }
 
-                    if (count === 6) {
-                        assert.equal(request.request.type, "AudioPlayer.PlaybackStarted");
-                        done();
+                        if (count === 6) {
+                            assert.equal(request.request.type, "AudioPlayer.PlaybackStarted");
+                            done();
+                        }
+                    } catch (error) {
+                        done(error);
                     }
                 });
 
                 alexa.intended("PlayIntent", null, function () {
                     alexa.playbackFinished(function (error, response, request) {
-                        assert.equal(response.response.directives[0].audioItem.stream.token, "3");
+                        try {
+                            assert.equal(response.response.directives[0].audioItem.stream.token, "3");
+                        } catch (error) {
+                            done(error);
+                        }
                         alexa.playbackFinished();
                     });
                 });
@@ -376,19 +401,26 @@ describe("BSTAlexa", function() {
                 this.timeout(5000);
                 let count = 0;
                 alexa.on("response", function (response: any, request: any) {
-                    console.log("RequestType: " + request.request.type);
-                    count++;
-                    if (count === 3) {
-                        assert.equal(request.request.type, "AudioPlayer.PlaybackNearlyFinished");
-                        assert.equal(request.request.token, "1");
-                        assert.equal(request.request.offsetInMilliseconds, 0);
-                        done();
+                    try {
+                        count++;
+                        if (count === 3) {
+                            assert.equal(request.request.type, "AudioPlayer.PlaybackNearlyFinished");
+                            assert.equal(request.request.token, "1");
+                            assert.equal(request.request.offsetInMilliseconds, 0);
+                            done();
+                        }
+                    } catch (error) {
+                        done(error);
                     }
                 });
 
                 alexa.intended("PlayIntent", null, function () {
                     alexa.playbackNearlyFinished(function (error, response, request) {
-                        assert.equal(response.response.directives[0].audioItem.stream.token, "3");
+                        try {
+                            assert.equal(response.response.directives[0].audioItem.stream.token, "3");
+                        } catch (error) {
+                            done(error);
+                        }
                     });
                 });
             });
@@ -401,8 +433,12 @@ describe("BSTAlexa", function() {
                 alexa.intended("PlayIntent", null, function () {
                     alexa.on("AudioPlayer.PlaybackStarted", function () {
                         alexa.playbackStopped(function(error, response, request) {
-                            assert.equal(request.request.type, "AudioPlayer.PlaybackStopped");
-                            done();
+                            try {
+                                assert.equal(request.request.type, "AudioPlayer.PlaybackStopped");
+                                done();
+                            } catch (error) {
+                                done(error);
+                            }
                         });
                     });
                 });

--- a/test/client/bst-config-test.ts
+++ b/test/client/bst-config-test.ts
@@ -15,24 +15,24 @@ import {SpokesClient as mockSpokes} from "../mocks/mock-spokes";
 // Getting uuid with require because we have issues with typings
 const uuid =  require("uuid");
 
-mockery.enable({useCleanCache: true});
-mockery.warnOnUnregistered(false);
-mockery.warnOnReplace(false);
-mockery.registerMock("../external/source-name-generator", {
-    SourceNameGenerator: mockSourceNameGenerator,
-});
-mockery.registerMock("../external/spokes", {
-    SpokesClient: mockSpokes,
-});
-
-const BSTConfig = require("../../lib/client/bst-config").BSTConfig;
+let BSTConfig;
 
 describe("BSTConfig", function() {
     this.timeout(30000);
 
     describe("#bootstrap()", function() {
         before(function () {
+            mockery.enable({useCleanCache: true});
+            mockery.warnOnUnregistered(false);
+            mockery.warnOnReplace(false);
+            mockery.registerMock("../external/source-name-generator", {
+                SourceNameGenerator: mockSourceNameGenerator,
+            });
+            mockery.registerMock("../external/spokes", {
+                SpokesClient: mockSpokes,
+            });
 
+            BSTConfig = require("../../lib/client/bst-config").BSTConfig;
             (<any> BSTConfig).configDirectory = function () {
                 return "test/resources/.bst";
             };
@@ -46,6 +46,11 @@ describe("BSTConfig", function() {
 
         afterEach(function () {
 
+        });
+
+        after(function () {
+            mockery.deregisterAll();
+            mockery.disable();
         });
 
         it("Test new config created correctly", async function () {

--- a/test/client/bst-deploy-test.ts
+++ b/test/client/bst-deploy-test.ts
@@ -48,9 +48,9 @@ describe("BST Deploy", async function() {
     let skip: boolean = false;
     let awsHelper = null;
 
-    before(async function() {
+    before(function() {
         this.timeout(10000);
-        await Global.initializeCLI();
+        Global.initialize(false, true);
         lambdaConfig = LambdaConfig.create();
         lambdaConfig.initialize();
         if (!lambdaConfig.AWS_ACCESS_KEY_ID) {
@@ -116,8 +116,8 @@ describe("BST Deploy", async function() {
     describe("prepares the lambda function code", function() {
         let deployer: LambdaDeploy = null;
 
-        before(async function () {
-            await Global.initializeCLI();
+        before(function () {
+            Global.initialize(false, true);
             lambdaConfig.initialize();
             deployer = LambdaDeploy.create(deployProject, lambdaConfig);
         });

--- a/test/client/bst-proxy-test.ts
+++ b/test/client/bst-proxy-test.ts
@@ -6,9 +6,9 @@ import {BespokeServer} from "../../lib/server/bespoke-server";
 import {BSTProxy} from "../../lib/client/bst-proxy";
 
 describe("BSTProxy", async function() {
-    before(async function() {
+    before(function() {
         this.timeout(10000);
-        await Global.initializeCLI();
+        Global.initialize(false, true);
     });
 
     describe("#http()", function() {

--- a/test/client/lambda-server-test.ts
+++ b/test/client/lambda-server-test.ts
@@ -7,7 +7,7 @@ import {Global} from "../../lib/core/global";
 
 describe("LambdaServer", function() {
     before(function () {
-        Global.initialize();
+        Global.initialize(false, true);
     });
 
     beforeEach(function () {

--- a/test/core/global-test.ts
+++ b/test/core/global-test.ts
@@ -20,6 +20,25 @@ describe("Global", function() {
             assert(Global.config());
         });
 
+        it("Have offline config once Initialized", function () {
+            Global.initialize(false, true);
+            assert.deepEqual(Global.config().configuration, {
+                sourceID: "0000000-0000-0000-0000-000000000000",
+                secretKey: "offline-mode",
+                lambdaDeploy: {
+                    runtime: "nodejs4.3",
+                    role: "lambda-bst-execution",
+                    handler: "index.handler",
+                    description: "My BST lambda skill",
+                    timeout: 3,
+                    memorySize: 128,
+                    vpcSubnets: "",
+                    vpcSecurityGroups: "",
+                    excludeGlobs: "event.json"
+                }
+            });
+        });
+
         it("Checks Running", function(done) {
             assert(Global.running() !== undefined);
             done();

--- a/test/mocks/mock-source-name-generator.ts
+++ b/test/mocks/mock-source-name-generator.ts
@@ -1,0 +1,13 @@
+const uuid = require("uuid");
+
+export class SourceNameGenerator {
+    public callService() {
+        const id = uuid.v4();
+        return {
+            id,
+            secretKey: "unit-test" + id,
+        };
+    };
+
+    public createDashboardSource () {};
+};

--- a/test/mocks/mock-spokes.ts
+++ b/test/mocks/mock-spokes.ts
@@ -1,0 +1,24 @@
+export class SpokesClient {
+    public constructor(private _id: string, private _secretKey: string) {
+    }
+
+    public verifyUUIDisNew() {
+        return true;
+    }
+
+    public createPipe () {
+        return {
+            uuid: this._secretKey,
+            diagnosticsKey: null,
+            endPoint: {
+                name: this._id
+            },
+            http: {
+                url: "https://proxy.bespoken.tools",
+            },
+            path: "/",
+            pipeType: "HTTP",
+            proxy: true
+        };
+    }
+}


### PR DESCRIPTION
- Add a offline mode for Global so that it don't call external services and works with a default config that it's not saved.
- Use offline mode for tests (Fixes #237).
- For testing bst-config mock our external client to our endpoints (Fixes #255).
- Fix issue with bst launch were it was not rendering "help" correctly.
- Re-enable a test that was skipped during test issues.