### PR TITLE
Restore proxy and dashboard links

### DIFF
--- a/bin/bst-proxy.ts
+++ b/bin/bst-proxy.ts
@@ -32,13 +32,12 @@ program
     .description("Proxies an HTTP service running at the specified port")
     .action(function (port: number, options: any) {
         console.log("Your URL for Alexa Skill configuration:");
-        console.log(URLMangler.mangleJustPath("/YOUR/SKILL/PATH", Global.config().secretKey()));
+        console.log(URLMangler.manglePipeToPath(Global.config().sourceID()));
         console.log("");
-        // TODO: Re-add this lines once dashboard configuration is ready
-        // console.log("Your URL for viewing skill data:");
-        // console.log(URLMangler.mangleJustPath("/YOUR/SKILL/PATH", Global.config().sourceID(), Global.config().secretKey()));
-        // console.log("(Be sure to put in your real path and other query string parameters!)");
-        // console.log("");
+        console.log("Your URL for viewing skill data:");
+        console.log(URLMangler.mangleJustPath("/YOUR/SKILL/PATH", Global.config().sourceID(), Global.config().secretKey()));
+        console.log("(Be sure to put in your real path and other query string parameters!)");
+        console.log("");
 
         let proxy: BSTProxy = BSTProxy.http(port);
         handleOptions(proxy, options);
@@ -54,13 +53,12 @@ program
     .description("Proxies a AWS Lambda defined in the specified file")
     .action(function (lambdaFile: string, options: any) {
         console.log("Your URL for Alexa Skill configuration:");
-        console.log(URLMangler.mangleNoPath(Global.config().secretKey()));
+        console.log(URLMangler.manglePipeToPath(Global.config().sourceID()));
         console.log("");
-        // TODO: Re-add this lines once dashboard configuration is ready
-        // console.log("Your URL for viewing skill data:");
-        // console.log(URLMangler.mangleNoPath(Global.config().sourceID(), Global.config().secretKey()));
-        // console.log("Copy and paste this to your browser to view your transaction history and summary data.");
-        // console.log("");
+        console.log("Your URL for viewing skill data:");
+        console.log(URLMangler.mangleNoPath(Global.config().sourceID(), Global.config().secretKey()));
+        console.log("Copy and paste this to your browser to view your transaction history and summary data.");
+        console.log("");
         let proxy: BSTProxy = BSTProxy.lambda(lambdaFile);
         handleOptions(proxy, options);
         proxy.start();
@@ -75,13 +73,12 @@ program
     .description("Proxies a Google HTTP Cloud Function defined in the specified file with the specified name")
     .action(function (functionFile: string, functionName: string, options: any) {
         console.log("Your URL for Fulfillment configuration:");
-        console.log(URLMangler.mangleNoPath(Global.config().secretKey()));
+        console.log(URLMangler.manglePipeToPath(Global.config().sourceID()));
         console.log("");
-        // TODO: Re-add this lines once dashboard configuration is ready
-        // console.log("Your URL for viewing skill data:");
-        // console.log(URLMangler.mangleNoPath(Global.config().sourceID(), Global.config().secretKey()));
-        // console.log("Copy and paste this to your browser to view your transaction history and summary data.");
-        // console.log("");
+        console.log("Your URL for viewing your function data:");
+        console.log(URLMangler.mangleNoPath(Global.config().sourceID(), Global.config().secretKey()));
+        console.log("Copy and paste this to your browser to view your transaction history and summary data.");
+        console.log("");
 
         let proxy: BSTProxy = BSTProxy.cloudFunction(functionFile, functionName);
         handleOptions(proxy, options);

--- a/bin/bst-proxy.ts
+++ b/bin/bst-proxy.ts
@@ -105,17 +105,6 @@ program
 
     });
 
-program
-    .command("urlgen <alexa-url>")
-    .description("Generates the URL to be used in the Alexa Skill configuration")
-    .action(function (url: string) {
-        let bstURL: string = BSTProxy.urlgen(url);
-        console.log("Enter this URL on the Configuration tab of your skill:");
-        console.log();
-        console.log("\t" + bstURL);
-        console.log();
-    });
-
 // Forces help to be printed if neither lambda nor HTTP is printed
 if (process.argv.length < 3) {
     program.outputHelp();

--- a/lib/client/bst-proxy.ts
+++ b/lib/client/bst-proxy.ts
@@ -71,15 +71,6 @@ export class BSTProxy {
     }
 
     /**
-     * Generates the URL to be used for Alexa configuration
-     * @param url
-     * @returns
-     */
-    public static urlgen(url: string): string {
-        return URLMangler.mangle(url, Global.config().secretKey());
-    }
-
-    /**
      * Specifies the host and port of the bespoken server to connect to
      * @param host
      * @param port

--- a/lib/client/bst-proxy.ts
+++ b/lib/client/bst-proxy.ts
@@ -2,7 +2,6 @@
 
 import {BespokeClient} from "./bespoke-client";
 import {LambdaServer} from "./lambda-server";
-import {URLMangler} from "./url-mangler";
 import {BSTProcess} from "./bst-config";
 import {Global} from "../core/global";
 import {FunctionServer} from "./function-server";

--- a/lib/client/url-mangler.ts
+++ b/lib/client/url-mangler.ts
@@ -2,33 +2,42 @@ import * as url from "url";
 import {Url} from "url";
 import {Global} from "../core/global";
 export class URLMangler {
-    public static mangle(urlString: string, nodeID: string): string {
+    public static mangle(urlString: string, sourceID: string, secretKey: string): string {
         let urlValue: Url = url.parse(urlString, true, false);
-        return URLMangler.mangleJustPath(urlValue.path, nodeID);
+        return URLMangler.mangleJustPath(urlValue.path, sourceID, secretKey);
     }
 
-    public static mangleJustPath(path: string, nodeID: string): string {
+    public static manglePipeToPath(sourceID: string) {
+        return `https://${ sourceID }.${ Global.SpokesPipeDomain }`;
+    }
+
+    public static mangleJustPath(path: string, sourceID: string, secretKey: string): string {
         let newUrl: string = "https://";
-        newUrl += Global.BespokeServerHost;
+        newUrl += Global.SpokesDashboardHost;
         newUrl += path;
         if (path.indexOf("?") !== -1) {
             newUrl += "&";
         } else {
             newUrl += "?";
         }
-        newUrl += "node-id=" + nodeID;
+        newUrl += "id=" + sourceID;
+        newUrl += "&key=" + secretKey;
+
         return newUrl;
     }
 
     /**
      * Creates the BST proxy URL when there is no path
-     * @param nodeID
+     * @param sourceID
+     * @returns {string}
+     * @param secretKey
      * @returns {string}
      */
-    public static mangleNoPath(nodeID: string): string {
+    public static mangleNoPath(sourceID: string, secretKey: string): string {
         let newUrl: string = "https://";
-        newUrl += Global.BespokeServerHost;
-        newUrl += "?node-id=" + nodeID;
+        newUrl += Global.SpokesDashboardHost;
+        newUrl += "?id=" + sourceID;
+        newUrl += "&key=" + secretKey;
         return newUrl;
     }
 }

--- a/test/bin/bst-proxy-test.ts
+++ b/test/bin/bst-proxy-test.ts
@@ -273,41 +273,6 @@ describe("bst-proxy", function() {
             NodeUtil.load("../../bin/bst-proxy.js");
         });
     });
-
-
-    describe("urlgen", function() {
-        it("Calls urlgen", function(done) {
-            process.argv = command("node bst-proxy.js urlgen http://jpk.com/test");
-
-            mockProxy.urlgen = function (url: string) {
-                assert.equal(url, "http://jpk.com/test");
-                done();
-            };
-
-            NodeUtil.load("../../bin/bst-proxy.js");
-        });
-
-        it("Prints the BST URL", function(done) {
-            process.argv = command("node bst-proxy.js urlgen http://jpk.com/test");
-            mockProxy.urlgen = function (url: string) {
-                return url;
-            };
-
-            let count = 0;
-            // Confirm the help prints out
-            sandbox.stub(console, "log", function (data: Buffer) {
-                count++;
-                if (data !== undefined) {
-                    console.error("Date: " + data.toString());
-                }
-                if (count === 3 && data.toString().indexOf("http") !== -1) {
-                    done();
-                }
-            });
-
-            NodeUtil.load("../../bin/bst-proxy.js");
-        });
-    });
 });
 
 let command = function (command: string): Array<string> {

--- a/test/client/bst-proxy-test.ts
+++ b/test/client/bst-proxy-test.ts
@@ -98,12 +98,4 @@ describe("BSTProxy", async function() {
             });
         });
     });
-
-    describe("#urlgen()", function() {
-        it("Starts and Stops Correctly", function (done) {
-            let url = BSTProxy.urlgen("http://jpk.com/test");
-            assert.equal(url, "https://proxy.bespoken.tools/test?node-id=" + Global.config().secretKey());
-            done();
-        });
-    });
 });

--- a/test/client/url-mangler-test.ts
+++ b/test/client/url-mangler-test.ts
@@ -7,30 +7,38 @@ import {Global} from "../../lib/core/global";
 describe("URLMangler", function() {
     describe("#mangle()", function() {
         it("Mangles a URL without a query string", function(done) {
-            let newUrl = URLMangler.mangle("http://myservice.xapp.com:5000/test", "JPK");
-            assert.equal(newUrl, "https://" + Global.BespokeServerHost + "/test?node-id=JPK");
+            let newUrl = URLMangler.mangle("http://myservice.xapp.com:5000/test", "JPK", "secret");
+            assert.equal(newUrl, "https://" + Global.SpokesDashboardHost + "/test?id=JPK&key=secret");
             done();
         });
 
         it("Mangles a URL with a query string", function(done) {
-            let newUrl: string = URLMangler.mangle("http://myservice.xapp.com:5000/test?test=2", "BST");
-            assert.equal(newUrl, "https://" + Global.BespokeServerHost + "/test?test=2&node-id=BST");
+            let newUrl: string = URLMangler.mangle("http://myservice.xapp.com:5000/test?test=2", "BST", "secret");
+            assert.equal(newUrl, "https://" + Global.SpokesDashboardHost + "/test?test=2&id=BST&key=secret");
             done();
         });
     });
 
     describe("#mangleNoPath()", function() {
         it("Mangles a URL without a path", function(done) {
-            let newUrl = URLMangler.mangleNoPath("JPK");
-            assert.equal(newUrl, "https://" + Global.BespokeServerHost + "?node-id=JPK");
+            let newUrl = URLMangler.mangleNoPath("JPK", "secret");
+            assert.equal(newUrl, "https://" + Global.SpokesDashboardHost + "?id=JPK&key=secret");
             done();
         });
     });
 
     describe("#mangleJustPath()", function() {
         it("Mangles a URL without a path", function(done) {
-            let newUrl = URLMangler.mangleJustPath("/YOUR/PATH", "JPK");
-            assert.equal(newUrl, "https://" + Global.BespokeServerHost + "/YOUR/PATH?node-id=JPK");
+            let newUrl = URLMangler.mangleJustPath("/YOUR/PATH", "JPK", "secret");
+            assert.equal(newUrl, "https://" + Global.SpokesDashboardHost + "/YOUR/PATH?id=JPK&key=secret");
+            done();
+        });
+    });
+
+    describe("#mangleJustPath()", function() {
+        it("Mangles a Pipe with Domain", function(done) {
+            let newUrl = URLMangler.manglePipeToPath("JPK");
+            assert.equal(newUrl, "https://JPK." + Global.SpokesPipeDomain);
             done();
         });
     });


### PR DESCRIPTION
- Restore `<name>.bespoken.link ` names for configuration and link to dashboard for skill diagnostics.
- Remove bst proxy urlgen