### PR TITLE
Add liveDebug flag to source generation (Closes #295)

### DIFF
--- a/lib/external/source-name-generator.ts
+++ b/lib/external/source-name-generator.ts
@@ -20,6 +20,7 @@ export class SourceNameGenerator {
                     id,
                     secretKey,
                     name: id,
+                    liveDebug: true,
                 },
             },
             json: true,

--- a/test/external/source-name-generator-test.ts
+++ b/test/external/source-name-generator-test.ts
@@ -44,6 +44,7 @@ describe("Source Name Generator", function() {
                     id: "id",
                     secretKey: "secretKey",
                     name: "id",
+                    liveDebug: true,
                 },
             },
             json: true,


### PR DESCRIPTION
Closes #295 
Should not be published to NPM until  bespoken/source-name-generator#8 is closed