### PR TITLE
Preserve Secret Key for users of version 0.9.37 onwards

### DIFF
--- a/lib/client/bst-config.ts
+++ b/lib/client/bst-config.ts
@@ -100,7 +100,7 @@ export class BSTConfig {
     }
 
     private static async updateConfig(config: any): Promise<void> {
-        const generatedConfig = await BSTConfig.createConfig(config.nodeID);
+        const generatedConfig = await BSTConfig.createConfig(config.nodeID || config.secretKey);
         config.sourceID = generatedConfig.sourceID;
         config.secretKey = generatedConfig.secretKey;
         config.version = generatedConfig.version;

--- a/test/client/bst-config-test.ts
+++ b/test/client/bst-config-test.ts
@@ -111,14 +111,12 @@ describe("BSTConfig", function() {
             assert.notEqual(typeof config.sourceID(), "undefined");
         });
 
-        it("Discard old sourceId and secretKey when it doesn't have a version", async function () {
+        it("Discard old sourceId when it doesn't have a version", async function () {
             // we load in order to create the file
             await BSTConfig.load();
-            const nodeID = uuid.v4();
             const oldConfiguration = {
-                nodeID,
-                secretKey: "thisWontPersist",
-                sourceID: "thisWontPersistEither",
+                secretKey: "thisWillPersist",
+                sourceID: "thisWontPersist",
                 lambdaDeploy: {
                     runtime: "nodejs4.3",
                     role: "",
@@ -139,8 +137,10 @@ describe("BSTConfig", function() {
             let config = await BSTConfig.load();
 
             // assert we have the new keys
-            assert.equal(config.secretKey(), nodeID);
+            assert.equal(config.secretKey(), "thisWillPersist");
             assert.notEqual(typeof config.sourceID(), "undefined");
+            assert.notEqual(config.sourceID(), "thisWontPersist");
+
         });
     });
 });


### PR DESCRIPTION
This will preserve the secret key for users of version 0.9.37 (since we started using secretKey and sourceId but not showing it). This will assure that nodeId works as expected.

Warning: this will generate issues for users that are using the beta versions and using dashboard since their spokes pipes were not removed and the uuid will be reported as existent.