### PR TITLE
Augment LambdaServer to use URL path parameter from request to lookup

### DIFF
--- a/lib/client/lambda-server.ts
+++ b/lib/client/lambda-server.ts
@@ -96,12 +96,12 @@ export class LambdaServer {
         const context: LambdaContext = new LambdaContext(request, body, response, this.verbose);
 
         if (request.url !== "/") {
-            // verify that path does not contain '..' or node_modules anywhere
-            if (/(.*\.\.)|(.*node_modules)/.test(request.url)) {
-                context.fail(Error(`LambdaServer input url should not contain '..' or node_modules characters found: ${request.url}`));
+            // verify that path does not contain more than one '.' or node_modules anywhere
+            if (/(.*\..*\.)|(.*node_modules)/.test(request.url)) {
+                context.fail(Error(`LambdaServer input url should not contain more than '.' or node_modules.  found: ${request.url}`));
                 return;
             }
-            [path, handlerFunction] = request.url.split(":");
+            [path, handlerFunction] = request.url.split(".");
         }
         else {
             // no url argument supplied -- use file parameter (supplied in constructor) instead
@@ -121,7 +121,7 @@ export class LambdaServer {
                 console.log(JSON.stringify(bodyJSON, null, 2));
             }
 
-            handlerFunction = handlerFunction != null ? handlerFunction : this.functionName ? this.functionName : "handler";
+            handlerFunction = handlerFunction ? handlerFunction : this.functionName ? this.functionName : "handler";
             lambda[handlerFunction](bodyJSON, context, function(error: Error, result: any) {
                 context.done(error, result);
             });


### PR DESCRIPTION
module information when path information is supplied in url.

Towards closing #334

Not specifically mentioned in the discussion on the issue -- was the question of how to encode the module and handler names in the url.  In this PR I interpret the ":" character as a special character to separate module path from handler -- I believe ':''s are not allowed in node paths ...?  

That may not be the 'right way' though -- serverless config file uses a '.' format which I personally find to be a pretty bad choice -- maybe using that convention would be better here ...  example code in use in various bst context's uses path/to/SomeFunction.js as the module representation though and I was worried about compatibility if I tried to use '.' as the path/handler separator ...