### PR TITLE
Make lambdaFile argument to bst-proxy command optional

### DIFF
--- a/bin/bst-proxy.ts
+++ b/bin/bst-proxy.ts
@@ -59,7 +59,7 @@ program
     });
 
 program
-    .command("lambda <lambda-file> [function-name]")
+    .command("lambda [lambda-file] [function-name]")
     .option("--bstHost <bstHost>", "The host name of the BST server")
     .option("--bstPort <bstPort>", "The port of the BST server", parseInt)
     .option("--pithy", "Disables verbose diagnostics")

--- a/lib/client/bst-proxy.ts
+++ b/lib/client/bst-proxy.ts
@@ -67,7 +67,7 @@ export class BSTProxy {
      * @param lambdaFile
      * @returns {BSTProxy}
      */
-    public static lambda(lambdaFile: string, functionName?: string): BSTProxy {
+    public static lambda(lambdaFile?: string, functionName?: string): BSTProxy {
         let tool: BSTProxy = new BSTProxy(ProxyType.LAMBDA);
         tool.functionFile = lambdaFile;
         tool.functionName = functionName;


### PR DESCRIPTION
I would like to invoke command from serverless-plugin-bespoken without arguments -- here's attempt to make lambdaFile argument to bst-proxy command optional.