### PR TITLE
Ensure all content size verification and slicing is done with buffers

### DIFF
--- a/lib/client/bespoke-client.ts
+++ b/lib/client/bespoke-client.ts
@@ -121,7 +121,7 @@ export class BespokeClient {
 
         const tcpClient = new TCPClient(request.id() + "");
         const httpBuffer = new HTTPBuffer();
-        tcpClient.transmit(self.targetDomain, self.targetPort, request.toTCP(), function(data: Buffer, error: NetworkErrorType, message: string) {
+        tcpClient.transmit(self.targetDomain, self.targetPort, request.rawContents, function(data: Buffer, error: NetworkErrorType, message: string) {
 
             if (data != null) {
                 // Grab the body of the response payload
@@ -211,7 +211,7 @@ export class BespokeClient {
         } else if (socketMessage.contains(Global.KeepAliveMessage)) {
             this.keepAlive.received();
         } else {
-            this.onWebhookReceived(WebhookRequest.fromString(this.socketHandler.socket, socketMessage.asString(), socketMessage.getMessageID()));
+            this.onWebhookReceived(WebhookRequest.fromBuffer(this.socketHandler.socket, socketMessage.getMessage(), socketMessage.getMessageID()));
         }
     }
 

--- a/lib/client/bst-encode.ts
+++ b/lib/client/bst-encode.ts
@@ -4,7 +4,7 @@
 
 import {FileUtil} from "../core/file-util";
 import * as path from "path";
-import * as http from "http";
+import * as https from "https";
 import {IncomingMessage} from "http";
 const AWS = require("aws-sdk");
 
@@ -155,8 +155,10 @@ export class BSTEncode {
             (<any> options.headers).filterVolume = this._configuration.filterVolume + "";
         }
 
+        console.log("OPtions: ", options);
+
         let responseData = "";
-        const request = http.request(options, function (response: IncomingMessage) {
+        const request = https.request(options, function (response: IncomingMessage) {
             if (response.statusCode !== 200) {
                 callback(new Error(response.statusMessage), null);
             } else {

--- a/lib/client/bst-encode.ts
+++ b/lib/client/bst-encode.ts
@@ -155,8 +155,6 @@ export class BSTEncode {
             (<any> options.headers).filterVolume = this._configuration.filterVolume + "";
         }
 
-        console.log("OPtions: ", options);
-
         let responseData = "";
         const request = https.request(options, function (response: IncomingMessage) {
             if (response.statusCode !== 200) {

--- a/lib/client/lambda-server.ts
+++ b/lib/client/lambda-server.ts
@@ -103,6 +103,7 @@ export class LambdaServer {
             path = this.file;
         } else {
             if (onlyUrl !== "/") {
+
                 // verify that path does not contain more than one '.' or node_modules anywhere
                 if (/(.*\..*\.)|(.*node_modules)/.test(onlyUrl)) {
                     context.fail(Error(`LambdaServer input url should not contain more than '.' or node_modules.  found: ${onlyUrl}`));
@@ -118,6 +119,7 @@ export class LambdaServer {
                 return;
             }
         }
+
         LoggingHelper.debug(Logger, "Invoking Lambda: " + path);
 
         const lambda = this.moduleManager.module(path);

--- a/lib/client/tcp-client.ts
+++ b/lib/client/tcp-client.ts
@@ -12,7 +12,7 @@ export class TCPClient {
     public onCloseCallback: () => void;
     public constructor (public id: string) {}
 
-    public transmit(host: string, port: number, requestData: string, callback: TCPClientCallback) {
+    public transmit(host: string, port: number, requestData: Buffer, callback: TCPClientCallback) {
         let self = this;
         let client = new net.Socket();
         LoggingHelper.info(Logger, "Forwarding " + host + ":" + port);

--- a/lib/core/socket-handler.ts
+++ b/lib/core/socket-handler.ts
@@ -75,9 +75,7 @@ export class SocketHandler {
             this.buffer = Buffer.concat([this.buffer, data]);
         }
 
-        const dataString = this.buffer.toString();
-
-        const delimiterIndex = dataString.indexOf(Global.MessageDelimiter);
+        const delimiterIndex = this.buffer.indexOf(Global.MessageDelimiter);
 
         if (delimiterIndex > -1) {
             const messageIDIndex = delimiterIndex - Global.MessageIDLength;
@@ -86,14 +84,14 @@ export class SocketHandler {
 
             const message = this.buffer.slice(0, messageIDIndex);
             // Grab the message ID - it precedes the delimiter
-            const messageIDString = dataString.slice(delimiterIndex - Global.MessageIDLength, delimiterIndex);
+            const messageIDString = this.buffer.slice(delimiterIndex - Global.MessageIDLength, delimiterIndex).toString();
             const messageID: number = parseInt(messageIDString);
             if (isNaN(messageID) || (messageID + "").length < 13) {
                 badMessage = true;
             }
 
             if (badMessage) {
-                LoggingHelper.error(Logger, "Bad message received: " + dataString);
+                LoggingHelper.error(Logger, "Bad message received: " + this.buffer.toString());
             } else {
                 const socketMessage = new SocketMessage(message, messageID);
 

--- a/lib/server/node.ts
+++ b/lib/server/node.ts
@@ -12,7 +12,7 @@ export class Node {
     public forward(request: WebhookRequest): void {
         console.log("NODE " + this.id + " MSG-ID: " + request.id() + " Forwarding");
         this.requests[request.id()] = request;
-        this.socketHandler.send(new SocketMessage(request.toTCP(), request.id()));
+        this.socketHandler.send(new SocketMessage(request.rawContents, request.id()));
     }
 
     public handlingRequest(): boolean {

--- a/test/bin/bst-invalid-test.ts
+++ b/test/bin/bst-invalid-test.ts
@@ -66,7 +66,7 @@ describe("bst commands", function() {
         mockery.disable();
     });
 
-    this.timeout(2000);
+    this.timeout(3000);
 
     describe("Invalid deploy command", function() {
         it("Prints error with invalid command", function(done) {

--- a/test/client/lambda-server-test.ts
+++ b/test/client/lambda-server-test.ts
@@ -47,6 +47,21 @@ describe("LambdaServer", function() {
 
         });
 
+        it("Starts Correctly With a custom function with strange characters", function(done) {
+            let runner = new LambdaServer("ExampleLambdaCustomFunction.js", 10000, false, "myHandler");
+            runner.start();
+
+            let client = new HTTPClient();
+            let inputData = {"data": "Testü"};
+            client.post("localhost", 10000, "", JSON.stringify(inputData), function(data: Buffer) {
+                let responseString = data.toString();
+                assert.equal(responseString, "{\"success\":true}");
+                runner.stop();
+                done();
+            });
+
+        });
+
         it("Handles Lambda Fail Correctly", function(done) {
             let runner = new LambdaServer("ExampleLambda.js", 10000);
             runner.start();

--- a/test/server/node-manager-test.ts
+++ b/test/server/node-manager-test.ts
@@ -33,7 +33,7 @@ describe("NodeManager", function() {
                         done();
                     });
                 };
-                client.transmit("localhost", 9000, "{1234567890123" + Global.MessageDelimiter, function () {
+                client.transmit("localhost", 9000, Buffer.from("{1234567890123" + Global.MessageDelimiter), function () {
                     assert(false, "This should not be reached - no data should be sent back.");
                 });
             });


### PR DESCRIPTION
Relates to #393 and #423 

We were treating content always as a string when verifying the content length vs the data sent to check if all the data was processed. Also when receiving the data and dividing the message id, delimiter and the actual payload.
This worked fine for payloads containing JSON were the characters were always on bit , so the buffer length and the string length matched.
For binary data or JSON were there are special characters (ü) that use more than one bit, it was causing issues.

This PR address that by always doing the operations against the buffer 