### PR TITLE
Port80 support

### DIFF
--- a/bin/bst-server.ts
+++ b/bin/bst-server.ts
@@ -3,12 +3,18 @@ import {BespokeServer} from "../lib/server/bespoke-server";
 import * as program from "commander";
 
 program
-    .command("start <webhookPort> <nodePort>")
+    .command("start <webhookPort> <nodePorts ...>")
     .description("Starts the BST server")
     .action(function () {
         let webhookPort: number = parseInt(process.argv[3]);
-        let serverPort: number = parseInt(process.argv[4]);
-        let bespokeServer = new BespokeServer(webhookPort, serverPort);
+       
+        // We typically listen on multiple ports - 5000 and 80
+        // All the args after the webhook port are treated as node (tunnel) ports
+        let serverPorts: number[] = [];
+        for (let i = 4; i < process.argv.length; i++) {
+            serverPorts.push(parseInt(process.argv[i]));
+        }
+        let bespokeServer = new BespokeServer(webhookPort, serverPorts);
         bespokeServer.start();
     });
 

--- a/bin/bst-server.ts
+++ b/bin/bst-server.ts
@@ -6,15 +6,15 @@ program
     .command("start <webhookPort> <nodePorts ...>")
     .description("Starts the BST server")
     .action(function () {
-        let webhookPort: number = parseInt(process.argv[3]);
+        const webhookPort = parseInt(process.argv[3]);
 
         // We typically listen on multiple ports - 5000 and 80
         // All the args after the webhook port are treated as node (tunnel) ports
-        let serverPorts: number[] = [];
+        const serverPorts: number[] = [];
         for (let i = 4; i < process.argv.length; i++) {
             serverPorts.push(parseInt(process.argv[i]));
         }
-        let bespokeServer = new BespokeServer(webhookPort, serverPorts);
+        const bespokeServer = new BespokeServer(webhookPort, serverPorts);
         bespokeServer.start();
     });
 

--- a/bin/bst-server.ts
+++ b/bin/bst-server.ts
@@ -7,7 +7,7 @@ program
     .description("Starts the BST server")
     .action(function () {
         let webhookPort: number = parseInt(process.argv[3]);
-       
+
         // We typically listen on multiple ports - 5000 and 80
         // All the args after the webhook port are treated as node (tunnel) ports
         let serverPorts: number[] = [];

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,4 @@ RUN npm -version
 
 RUN npm install
 
-CMD node bin/bst-server.js start 443 5000
+CMD node bin/bst-server.js start 443 5000 80

--- a/lib/client/bst-proxy.ts
+++ b/lib/client/bst-proxy.ts
@@ -46,7 +46,7 @@ export class BSTProxy {
 
     private isSecure: boolean = false;
     private bespokenHost: string = "proxy.bespoken.tools";
-    private bespokenPort: number = 5000;
+    private bespokenPort: number = 80;
     private functionFile: string;
     private functionName: string;
     private httpPort: number;

--- a/lib/server/bespoke-server.ts
+++ b/lib/server/bespoke-server.ts
@@ -12,29 +12,19 @@ export class BespokeServer {
     private webhookManager: WebhookManager;
     private uncaughtExceptionHandler: (err: Error) => void;
 
-    public constructor (private webhookPort: number, private nodePort: number) {}
+    public constructor (private webhookPort: number, private nodePorts: number[]) {}
 
-    public start (started?: () => void): void {
+    public async start (): Promise<void> {
         BstStatistics.instance().start();
         let self = this;
         console.error("AWS_KEY: " + process.env["AWS_ACCESS_KEY_ID"]);
 
-        let count = 0;
-        // Make sure both NodeManager and WebhookManager have started
-        let callbackCounter = function () {
-            count++;
-            if (count === 2) {
-                if (started !== undefined && started !== null) {
-                    started();
-                }
-            }
-        };
-
-        this.nodeManager = new NodeManager(this.nodePort);
-        this.nodeManager.start(callbackCounter);
+        this.nodeManager = new NodeManager(this.nodePorts);
+        await this.nodeManager.start();
 
         this.webhookManager = new WebhookManager(this.webhookPort);
-        this.webhookManager.start(callbackCounter);
+        await this.webhookManager.start();
+
         this.webhookManager.onWebhookReceived = function(webhookRequest: WebhookRequest) {
             // Check if this is a ping
             if (webhookRequest.isPing()) {
@@ -80,23 +70,17 @@ export class BespokeServer {
         };
 
         process.on("uncaughtException", this.uncaughtExceptionHandler);
+        process.on("unhandledRejection", this.uncaughtExceptionHandler);
     }
 
-    public stop(callback: () => void): void {
+    public async stop(): Promise<void> {
         BstStatistics.instance().stop();
-        // Use a counter to see that both callbacks have completed
-        // The beauty of Node - use non-synchronized counter variables like this safely :-)
-        let count = 0;
-        let callbackFunction = function () {
-            count++;
-            if (count === 2) {
-                callback();
-            }
-        };
 
+        LoggingHelper.info(Logger, "BespkoenServer STOP");
         process.removeListener("uncaughtException", this.uncaughtExceptionHandler);
-        this.nodeManager.stop(callbackFunction);
-        this.webhookManager.stop(callbackFunction);
+        process.removeListener("unhandledRejection", this.uncaughtExceptionHandler);
+        await this.nodeManager.stop();
+        await this.webhookManager.stop();
     }
 
 }

--- a/lib/server/bespoke-server.ts
+++ b/lib/server/bespoke-server.ts
@@ -76,7 +76,7 @@ export class BespokeServer {
     public async stop(): Promise<void> {
         BstStatistics.instance().stop();
 
-        LoggingHelper.info(Logger, "BespkoenServer STOP");
+        LoggingHelper.info(Logger, "BespokenServer STOP");
         process.removeListener("uncaughtException", this.uncaughtExceptionHandler);
         process.removeListener("unhandledRejection", this.uncaughtExceptionHandler);
         await this.nodeManager.stop();

--- a/lib/server/node-manager.ts
+++ b/lib/server/node-manager.ts
@@ -12,26 +12,64 @@ export interface OnConnectCallback {
     (node: Node): void;
 }
 
+// The node manager handles the TCP tunnels from the clients
+// The node manager can (and typically does) listen on ports 5000 and 80
 export class NodeManager {
     public host: string = "0.0.0.0";
+    public nodes: {[id: string]: Node } = {};
+    private servers: NodeServer[];
     public onConnect: OnConnectCallback = null;
     public onNodeRemoved: (node: Node) => void = null; // Added for testability
 
-    private nodes: {[id: string]: Node } = {};
-    private server: Server;
-
-    constructor(private port: number) {}
+    constructor(private ports: number[]) {}
 
     public node (nodeID: string): Node {
         return this.nodes[nodeID];
     }
 
-    public start (callback?: () => void) {
-        const self = this;
-        this.server = net.createServer(function(socket: Socket) {
+    public async start (): Promise<void> {
+        this.servers = [];
+        // Create listeners on as many ports as specified
+        for (const port of this.ports) {
+            const server = new NodeServer(this, port);
+            await server.start();
+            this.servers.push(server);
+        }
+    }
+
+    public static onKeepAliveReceived(node: Node): void {
+        // Reply with the same message on a Keep Alive
+        node.socketHandler.send(new SocketMessage(Global.KeepAliveMessage));
+    }
+
+    /**
+     * Calling stop tells the server to stop listening
+     * However, connections are not closed until all sockets disconnect, so loop through sockets and force a disconnect
+     * @param callback
+     */
+    public async stop (): Promise<void> {
+        for (let key of Object.keys(this.nodes)) {
+            const node: Node = this.node(key);
+            node.socketHandler.disconnect();
+            LoggingHelper.info(Logger, "NODE CLOSING: " + node.id);
+        }
+
+        for (const server of this.servers) {
+            await server.stop();
+        }
+    }
+}
+
+// Sets up a listener for handling tunnels on the specified port
+class NodeServer {
+    private server: Server;
+    public constructor(private nodeManager: NodeManager, private port: number) {}
+
+    public start(): Promise<void> {
+        this.server = net.createServer((socket: Socket) => {
             let initialConnection = true;
             let node: Node = null;
-            const socketHandler = new SocketHandler(socket, function(socketMessage: SocketMessage) {
+            const socketHandler = new SocketHandler(socket, (socketMessage: SocketMessage) => {
                 // We do special handling when we first connect
                 const strMessage: string = socketMessage.asString();
 
@@ -46,13 +84,13 @@ export class NodeManager {
                     const connectData = socketMessage.asJSON();
 
                     node = new Node(connectData.id, socketHandler);
-                    self.nodes[node.id] = node;
+                    this.nodeManager.nodes[node.id] = node;
 
                     socketHandler.send(new SocketMessage("ACK"));
                     initialConnection = false;
 
-                    if (self.onConnect != null) {
-                        self.onConnect(node);
+                    if (this.nodeManager.onConnect != null) {
+                        this.nodeManager.onConnect(node);
                     }
 
                     // Capture the connection
@@ -67,12 +105,12 @@ export class NodeManager {
             });
 
             // When the socket closes, remove it from the dictionary
-            socketHandler.onCloseCallback = function() {
+            socketHandler.onCloseCallback = () => {
                 if (node !== null) {
                     LoggingHelper.info(Logger, "NODE CLOSED: " + node.id);
-                    delete self.nodes[node.id];
-                    if (self.onNodeRemoved !== undefined && self.onNodeRemoved !== null) {
-                        self.onNodeRemoved(node);
+                    delete this.nodeManager.nodes[node.id];
+                    if (this.nodeManager.onNodeRemoved !== undefined && this.nodeManager.onNodeRemoved !== null) {
+                        this.nodeManager.onNodeRemoved(node);
                     }
                 }
             };
@@ -80,43 +118,28 @@ export class NodeManager {
             // We have a connection - a socket object is assigned to the connection automatically
             LoggingHelper.info(Logger, "NODE CONNECTED: " + socket.remoteAddress + ":" + socket.remotePort);
 
-        }).listen(this.port, this.host);
+        }).listen(this.port, this.nodeManager.host);
 
         // Make a callback when the server starts up
-        this.server.on("listening", function () {
-            // On startup, call callback if defined
-            if (callback !== undefined && callback !== null) {
-                callback();
-            }
+        return new Promise((resolve) => {
+            this.server.on("listening", () => {
+                LoggingHelper.info(Logger, "NodeMgr Listening on " + this.nodeManager.host + ":" + this.port);
+                resolve();
+            });
         });
-
-        LoggingHelper.info(Logger, "Listening on " + this.host + ":" + this.port);
     }
 
-    private static onKeepAliveReceived(node: Node): void {
-        // Reply with the same message on a Keep Alive
-        node.socketHandler.send(new SocketMessage(Global.KeepAliveMessage));
-    }
-
-    /**
-     * Calling stop tells the server to stop listening
-     * However, connections are not closed until all sockets disconnect, so loop through sockets and force a disconnect
-     * @param callback
-     */
-    public stop (callback: () => void): void {
-        for (let key of Object.keys(this.nodes)) {
-            const node: Node = this.node(key);
-            node.socketHandler.disconnect();
-            LoggingHelper.info(Logger, "NODE CLOSING: " + node.id);
-        }
-
-        this.server.close(function (error: any) {
-            if (error !== undefined) {
-                LoggingHelper.error(Logger, "ERROR! NodeManager not stopped: " + error);
-            } else {
-                LoggingHelper.info(Logger, "STOPPED");
-                callback();
-            }
+    stop(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server.close(function (error: any) {
+                if (error !== undefined) {
+                    LoggingHelper.error(Logger, "ERROR! NodeManager not stopped: " + error);
+                    reject(error);
+                } else {
+                    LoggingHelper.info(Logger, "STOPPED");
+                    resolve();
+                }
+            });
         });
     }
 }

--- a/test/alexa/sample-utterances-test.ts
+++ b/test/alexa/sample-utterances-test.ts
@@ -48,7 +48,7 @@ describe("SamplesUtterances", function() {
 
         it("Passes error when bad file with no sample", function(done) {
             SampleUtterances.fromFile("test/alexa/resources/SampleUtterancesNoUtterance.txt", function (utterances: SampleUtterances, error?: string) {
-                assert.equal(error, "Invalid sample utterance: AnotherTest");
+                assert.equal(error.trim(), "Invalid sample utterance: AnotherTest");
                 done();
             });
         });

--- a/test/bin/bst-server-test.ts
+++ b/test/bin/bst-server-test.ts
@@ -15,11 +15,12 @@ describe("bst-server", function() {
 
     describe("start command", function() {
         it("Starts", function(done) {
-            process.argv = command("node bst-server.js start 4000 5000");
+            process.argv = command("node bst-server.js start 4000 5000 80");
             mockery.registerMock("../lib/server/bespoke-server", {
-                BespokeServer: function (port: number, port2: number) {
+                BespokeServer: function (port: number, ports: number[]) {
                     assert.equal(port, 4000);
-                    assert.equal(port2, 5000);
+                    assert.equal(ports[0], 5000);
+                    assert.equal(ports[1], 80);
 
                     this.start = function () {
                         done();

--- a/test/client/bespoke-client-test.ts
+++ b/test/client/bespoke-client-test.ts
@@ -183,7 +183,7 @@ describe("BespokeClient", function() {
         it("Fails", function() {
             this.timeout(8000);
             return new Promise(async (resolve, reject) => {
-                const nodeManager = new NodeManager(testPort);
+                const nodeManager = new NodeManager([testPort]);
                 let wasFailureFunctionOverwritten = false;
                 let failureCount = 0;
 
@@ -225,7 +225,7 @@ describe("BespokeClient", function() {
                     }
 
                     client.shutdown(function () {
-                        nodeManager.stop(function () {
+                        nodeManager.stop().then(() => {
                             BespokeClient.RECONNECT_MAX_RETRIES = 3;
 
                             resolve();
@@ -244,7 +244,7 @@ describe("BespokeClient", function() {
         this.timeout(8000);
         it("Gets lots of keep alives", async function() {
             return new Promise(async (resolve, reject) => {
-                const nodeManager = new NodeManager(testPort);
+                const nodeManager = new NodeManager([testPort]);
                 let count = 0;
                 (<any> NodeManager).onKeepAliveReceived = function (node: Node) {
                     count++;
@@ -278,7 +278,7 @@ describe("BespokeClient", function() {
                     }
 
                     client.shutdown(function () {
-                        nodeManager.stop(function () {
+                        nodeManager.stop().then (() => {
                             resolve();
                         });
                     });

--- a/test/client/bst-proxy-test.ts
+++ b/test/client/bst-proxy-test.ts
@@ -28,7 +28,7 @@ describe("BSTProxy Programmatic", function () {
         mockery.disable();
     });
     it("Starts and stops programmatically", function (done) {
-        let proxy = BSTProxy.http(9999).secretKey("SECRET_KEY");
+        let proxy = BSTProxy.http(9999).bespokenServer("proxy.bespoken.tools", 5000).secretKey("SECRET_KEY");
         proxy.start(() => {
             assert.equal("SECRET_KEY", (proxy as any).bespokenClient.nodeID);
             proxy.stop(() => {
@@ -39,7 +39,7 @@ describe("BSTProxy Programmatic", function () {
 
     it("Fails to start programmatically without secret key", function (done) {
         const mockifiedProxy = require("../../lib/client/bst-proxy").BSTProxy;
-        let proxy = mockifiedProxy.http(9999);
+        let proxy = mockifiedProxy.http(9999).bespokenServer("proxy.bespoken.tools", 5000);
 
         proxy.start(() => {
             assert.equal("SECRET_KEY", (proxy as any).bespokenClient.nodeID);
@@ -63,14 +63,14 @@ describe("BSTProxy", async function() {
         const Global = require("../../lib/core/global").Global;
         await Global.initializeCLI();
         BespokeServer = require("../../lib/server/bespoke-server").BespokeServer;
-
+        
     });
 
     describe("#http()", function() {
         it("Starts and Stops Correctly", function (done) {
-            const server = new BespokeServer(4000, 5000);
-            server.start(function () {
-                const proxy = BSTProxy.http(5000);
+            const server = new BespokeServer(4000, [80]);
+            server.start().then(() => {
+                const proxy = BSTProxy.http(5000).bespokenServer("localhost", 80);
                 proxy.start(function () {
                     let count = 0;
                     const bothDone = function () {
@@ -81,14 +81,14 @@ describe("BSTProxy", async function() {
                     };
 
                     proxy.stop(bothDone);
-                    server.stop(bothDone);
+                    server.stop().then(() => bothDone());
                 });
             });
         });
 
         it("Starts and Stops Correctly With Options", function (done) {
-            const server = new BespokeServer(4000, 3000);
-            server.start(function () {
+            const server = new BespokeServer(4000, [3000]);
+            server.start().then(() => {
                 const proxy = BSTProxy.http(9999)
                     .bespokenServer("localhost", 3000);
                 proxy.activateSecurity();
@@ -103,7 +103,7 @@ describe("BSTProxy", async function() {
                     };
 
                     proxy.stop(bothDone);
-                    server.stop(bothDone);
+                    server.stop().then(() => bothDone());
                 });
             });
         });
@@ -111,10 +111,10 @@ describe("BSTProxy", async function() {
 
     describe("#lambda()", function() {
         it("Starts and Stops Correctly", function (done) {
-            const server = new BespokeServer(4000, 5000);
-            server.start(function () {
+            const server = new BespokeServer(4000, [5000]);
+            server.start().then(() => {
                 const proxy = BSTProxy.lambda("../resources/ExampleLambda.js");
-                proxy.port(2000);
+                proxy.port(2000).bespokenServer("localhost", 5000);
                 proxy.start(function () {
                     assert.equal((<any> proxy).lambdaServer.server.address().port, 2000);
 
@@ -127,16 +127,16 @@ describe("BSTProxy", async function() {
                     };
 
                     proxy.stop(bothDone);
-                    server.stop(bothDone);
+                    server.stop().then(() => bothDone());
                 });
             });
         });
 
         it("Starts and Stops Correctly With Named Function", function (done) {
-            const server = new BespokeServer(4000, 5000);
-            server.start(function () {
+            const server = new BespokeServer(4000, [5000]);
+            server.start().then(() => {
                 const proxy = BSTProxy.lambda("../resources/ExampleLambdaCustomFunction.js", "myHandler");
-                proxy.port(2000);
+                proxy.port(2000).bespokenServer("localhost", 5000);
                 proxy.start(function () {
                     assert.equal((<any> proxy).lambdaServer.server.address().port, 2000);
 
@@ -149,7 +149,7 @@ describe("BSTProxy", async function() {
                     };
 
                     proxy.stop(bothDone);
-                    server.stop(bothDone);
+                    server.stop().then(() => bothDone());
                 });
             });
         });
@@ -157,10 +157,10 @@ describe("BSTProxy", async function() {
 
     describe("#cloudFunction()", function() {
         it("Starts and Stops Correctly", function (done) {
-            const server = new BespokeServer(4000, 5000);
-            server.start(function () {
+            const server = new BespokeServer(4000, [5000]);
+            server.start().then(() => {
                 const proxy = BSTProxy.cloudFunction("../resources/ExampleFunction.js");
-                proxy.port(2000);
+                proxy.port(2000).bespokenServer("localhost", 5000);
                 proxy.start(function () {
                     assert.equal((<any> proxy).functionServer.server.address().port, 2000);
 
@@ -173,7 +173,7 @@ describe("BSTProxy", async function() {
                     };
 
                     proxy.stop(bothDone);
-                    server.stop(bothDone);
+                    server.stop().then(() => bothDone());
                 });
             });
         });

--- a/test/client/bst-proxy-test.ts
+++ b/test/client/bst-proxy-test.ts
@@ -63,7 +63,6 @@ describe("BSTProxy", async function() {
         const Global = require("../../lib/core/global").Global;
         await Global.initializeCLI();
         BespokeServer = require("../../lib/server/bespoke-server").BespokeServer;
-        
     });
 
     describe("#http()", function() {

--- a/test/client/bst-proxy-test.ts
+++ b/test/client/bst-proxy-test.ts
@@ -67,9 +67,9 @@ describe("BSTProxy", async function() {
 
     describe("#http()", function() {
         it("Starts and Stops Correctly", function (done) {
-            const server = new BespokeServer(4000, [80]);
+            const server = new BespokeServer(4000, [5001]);
             server.start().then(() => {
-                const proxy = BSTProxy.http(5000).bespokenServer("localhost", 80);
+                const proxy = BSTProxy.http(5000).bespokenServer("localhost", 5001);
                 proxy.start(function () {
                     let count = 0;
                     const bothDone = function () {

--- a/test/server/bespoke-server-test.ts
+++ b/test/server/bespoke-server-test.ts
@@ -16,12 +16,12 @@ describe("BespokeServerTest", function() {
         delete process.env.SSL_CERT;
     });
 
-    describe.only("ReceiveWebhook", function() {
+    describe("ReceiveWebhook", function() {
         it("Connects and Receives Callback", function(done) {
             this.timeout(2000);
             // Start the server - try this new-fangled asyncawait library as I'm tired of all the callbacks
             //  in my unit tests
-            let server = new BespokeServer(8010, [9010]);
+            const server = new BespokeServer(8010, [9010]);
             server.start();
 
             // Connect a client

--- a/test/server/bespoke-server-test.ts
+++ b/test/server/bespoke-server-test.ts
@@ -16,12 +16,12 @@ describe("BespokeServerTest", function() {
         delete process.env.SSL_CERT;
     });
 
-    describe("ReceiveWebhook", function() {
+    describe.only("ReceiveWebhook", function() {
         it("Connects and Receives Callback", function(done) {
             this.timeout(2000);
             // Start the server - try this new-fangled asyncawait library as I'm tired of all the callbacks
             //  in my unit tests
-            let server = new BespokeServer(8010, 9010);
+            let server = new BespokeServer(8010, [9010]);
             server.start();
 
             // Connect a client
@@ -42,7 +42,7 @@ describe("BespokeServerTest", function() {
                     let json = JSON.parse(data.toString());
                     assert.equal(json.data, "test");
                     bespokeClient.shutdown(function () {
-                        server.stop(function () {
+                        server.stop().then(() => {
                             done();
                         });
                     });
@@ -56,11 +56,11 @@ describe("BespokeServerTest", function() {
             this.timeout(10000);
 
             // Start all the stuff
-            let server = new BespokeServer(8010, 9010);
+            let server = new BespokeServer(8010, [9010]);
             let lambdaServer = new LambdaServer("./test/resources/DelayedLambda.js", 10000);
             let bespokeClient = new BespokeClient("JPK", "localhost", 9010, "localhost", 10000);
 
-            server.start(function () {
+            server.start().then(() => {
                 lambdaServer.start(function () {
                     bespokeClient.connect(function () {
                         onStarted();
@@ -93,7 +93,7 @@ describe("BespokeServerTest", function() {
                 if (count === 2) {
                     lambdaServer.stop(function () {
                         bespokeClient.shutdown(function () {
-                            server.stop(function () {
+                            server.stop().then(() => {
                                 done();
                             });
                         });
@@ -105,7 +105,7 @@ describe("BespokeServerTest", function() {
         it("Connects NoOp Lambda", function(done) {
             this.timeout(2000);
             // Start the server
-            let server = new BespokeServer(8010, 9010);
+            let server = new BespokeServer(8010, [9010]);
             server.start();
 
             let badLambda = new LambdaServer("./test/resources/NoOpLambda.js", 10000, true);
@@ -116,7 +116,7 @@ describe("BespokeServerTest", function() {
                 assert.equal(count, 1);
                 badLambda.stop(function () {
                     bespokeClient.shutdown(function () {
-                        server.stop(function () {
+                        server.stop().then(() => {
                             done();
                         });
                     });
@@ -145,8 +145,8 @@ describe("BespokeServerTest", function() {
         it("Handles Error Connecting To Target Server", function(done) {
             this.timeout(2000);
             // Start the server
-            let server = new BespokeServer(8000, 9000);
-            server.start(function () {
+            let server = new BespokeServer(8000, [9000]);
+            server.start().then(() => {
                 // Connect a client
                 let bespokeClient = new BespokeClient("JPK", "localhost", 9000, "localhost", 9001);
                 bespokeClient.onConnect = function () {
@@ -157,7 +157,7 @@ describe("BespokeServerTest", function() {
                 bespokeClient.connect();
                 bespokeClient.onError = function() {
                     bespokeClient.shutdown();
-                    server.stop(function () {
+                    server.stop().then(() => {
                         done();
                     });
                 };
@@ -167,15 +167,15 @@ describe("BespokeServerTest", function() {
         it("Handles Bad Node", function(done) {
             this.timeout(2000);
             // Start the server
-            let server = new BespokeServer(8000, 9000);
+            let server = new BespokeServer(8000, [9000]);
 
-            server.start(function () {
+            server.start().then(() => {
                 let webhookCaller = new HTTPClient();
                 webhookCaller.post("localhost", 8000, "/?node-id=JPK", "Test", function (body: any, statusCode: number) {
                     assert.equal(body, "Node is not active: JPK");
                     assert.equal(statusCode, 404);
 
-                    server.stop(function () {
+                    server.stop().then(() => {
                         done();
                     });
                 });
@@ -185,15 +185,15 @@ describe("BespokeServerTest", function() {
         it("Handles Multiple Nodes", function(done) {
             this.timeout(2000);
             // Start the server
-            let server = new BespokeServer(8000, 9000);
+            let server = new BespokeServer(8000, [9000]);
 
-            server.start(function () {
+            server.start().then(() => {
                 let webhookCaller = new HTTPClient();
                 webhookCaller.post("localhost", 8000, "/?node-id=JPK&node-id=JPK", "Test", function (body: any, statusCode: number) {
                     assert.equal(body, "Only one node-id should be present in the query");
                     assert.equal(statusCode, 400);
 
-                    server.stop(function () {
+                    server.stop().then(() => {
                         done();
                     });
                 });
@@ -203,38 +203,19 @@ describe("BespokeServerTest", function() {
         it("Handles No Node", function(done) {
             this.timeout(2000);
             // Start the server
-            let server = new BespokeServer(8000, 9000);
+            let server = new BespokeServer(8000, [9000]);
 
-            server.start(function () {
+            server.start().then(() => {
                 let webhookCaller = new HTTPClient();
                 webhookCaller.post("localhost", 8000, "/", "Test", function (body: any, statusCode: number) {
                     assert.equal(body, "No node specified. Must be included with the querystring as node-id.");
                     assert.equal(statusCode, 400);
 
-                    server.stop(function () {
+                    server.stop().then(() => {
                         done();
                     });
                 });
             });
-        });
-
-        it("Handles Uncaught Exception", function(done) {
-            this.timeout(2000);
-            // Start the server
-            let server = new BespokeServer(8000, 9000);
-            let mochaHandler = process.listeners("uncaughtException").pop();
-            process.removeListener("uncaughtException", mochaHandler);
-
-            server.start(function () {
-                throw new Error("Test");
-            });
-
-            setTimeout(function () {
-                server.stop(function () {
-                    process.addListener("uncaughtException", mochaHandler);
-                    done();
-                });
-            }, 10);
         });
     });
 
@@ -242,13 +223,13 @@ describe("BespokeServerTest", function() {
         it("Pings", function(done) {
             this.timeout(2000);
             // Start the server
-            let server = new BespokeServer(8000, 9000);
-            server.start(function () {
+            let server = new BespokeServer(8000, [9000]);
+            server.start().then(() => {
                 request.get("http://localhost:8000/ping", function (error: any, response: IncomingMessage, body: Buffer) {
                     assert(!error);
                     assert.equal(response.statusCode, 200);
                     assert.equal(body, "bst-server-" + Global.version());
-                    server.stop(function () {
+                    server.stop().then(() => {
                         done();
                     });
                 });

--- a/test/server/node-manager-test.ts
+++ b/test/server/node-manager-test.ts
@@ -13,7 +13,6 @@ describe("NodeManager", function() {
             let client = new BespokeClient("JPK", "localhost", 9000, "localhost", 9001);
 
             nodeManager.onConnect = function (node: Node) {
-                console.log("ON CONNECT")
                 assert.equal("127.0.0.1", node.socketHandler.remoteAddress());
                 nodeManager.stop().then(() => {
                     done();

--- a/test/server/node-manager-test.ts
+++ b/test/server/node-manager-test.ts
@@ -9,12 +9,13 @@ import {Global} from "../../lib/core/global";
 describe("NodeManager", function() {
     describe("Connect", function() {
         it("Connected And Received Data", function(done) {
-            let nodeManager = new NodeManager(9000);
+            let nodeManager = new NodeManager([9000]);
             let client = new BespokeClient("JPK", "localhost", 9000, "localhost", 9001);
 
             nodeManager.onConnect = function (node: Node) {
+                console.log("ON CONNECT")
                 assert.equal("127.0.0.1", node.socketHandler.remoteAddress());
-                nodeManager.stop(function() {
+                nodeManager.stop().then(() => {
                     done();
                 });
             };
@@ -24,12 +25,12 @@ describe("NodeManager", function() {
         });
 
         it("Connected And Sends Bad Data", function(done) {
-            let nodeManager = new NodeManager(9000);
-            nodeManager.start(function () {
+            let nodeManager = new NodeManager([9000]);
+            nodeManager.start().then(() => {
                 let client = new TCPClient("MYID");
                 client.onCloseCallback = function () {
                     // This should get called
-                    nodeManager.stop(function() {
+                    nodeManager.stop().then(() => {
                         done();
                     });
                 };
@@ -40,7 +41,7 @@ describe("NodeManager", function() {
         });
 
         it("Removes Node From Node Hash On Client Close", function(done) {
-            let nodeManager = new NodeManager(9000);
+            let nodeManager = new NodeManager([9000]);
             let client = new BespokeClient("JPK", "localhost", 9000, "localhost", 9001);
 
             nodeManager.onConnect = function (node: Node) {
@@ -53,7 +54,7 @@ describe("NodeManager", function() {
 
             nodeManager.onNodeRemoved = function () {
                 assert.equal(Object.keys((<any> nodeManager).nodes).length, 0);
-                nodeManager.stop(function() {
+                nodeManager.stop().then(() => {
                     done();
                 });
             };
@@ -65,10 +66,10 @@ describe("NodeManager", function() {
 
     describe("Close", function() {
         it("Closed Successfully", function (done) {
-            let nodeManager = new NodeManager(9000);
+            let nodeManager = new NodeManager([9000]);
 
-            nodeManager.start(function() {
-                nodeManager.stop(function () {
+            nodeManager.start().then(() => {
+                nodeManager.stop().then(() => {
                     done();
                 });
             });

--- a/test/server/webhook-manager-test.ts
+++ b/test/server/webhook-manager-test.ts
@@ -23,7 +23,7 @@ describe("WebhookManager", function() {
                 assert.equal(request.nodeID(), 10);
                 assert.equal((request.id() + "").length, 13);
                 assert.equal(request.body, "Test");
-                manager.stop(function () {
+                manager.stop().then(() => {
                     done();
                 });
             };
@@ -46,7 +46,7 @@ describe("WebhookManager", function() {
                 assert.equal((request.id() + "").length, 13);
                 assert.equal(request.body, "Test");
                 if (count === 2) {
-                    manager.stop(function () {
+                    manager.stop().then(() => {
                         done();
                     });
                 }


### PR DESCRIPTION
Adds support for bst-server to listen on port 80 in addition to port 5000 for the connection between the proxy client and the server.

- [X] Adds support for listening for TCP connections on multiple ports
- [X] Adds a TCP listener on port 80 alongside 5000
- [X] Changes client to connect to port 80 by default (though still configurable)
- [X] Still listens on 5000 for backward compatibility

Closes #562 