### PR TITLE
FEAT-609: Remove docs.bespoken.io from search engine web crawlers

### DIFF
--- a/custom_theme/main.html
+++ b/custom_theme/main.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
+    <meta name="robots" content="noindex" />
+  </head>
+  <body>
+    {{ page.content }}
+  </body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,10 @@ pages:
     - Debugging Lambdas Locally: tutorials/tutorial_lambda_debugger.md
     - Deploying Lambdas: tutorials/tutorial_lambda_deploy.md
 
-theme: readthedocs
+theme:
+  name: readthedocs
+  custom_dir: custom_theme/
 markdown_extensions:
 - attr_list
+- meta
 extra_css: [assets/css/style.css]


### PR DESCRIPTION
Relates to #609 