### PR TITLE
Publishing bst version 2.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -870,9 +870,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
-      "integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
+      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -971,9 +971,9 @@
       }
     },
     "@types/istanbul-lib-coverage": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
@@ -8904,9 +8904,9 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "skill-testing-ml": {
-      "version": "1.2.81",
-      "resolved": "https://registry.npmjs.org/skill-testing-ml/-/skill-testing-ml-1.2.81.tgz",
-      "integrity": "sha512-Cnk+3THzwAp7gmrZlAyU6ki7oayRccN/N28OZFn4xgA2PJzamR7mSHheHoCnLwNDEUTTmYCg+MS4b/S8MlDZcA==",
+      "version": "1.2.82",
+      "resolved": "https://registry.npmjs.org/skill-testing-ml/-/skill-testing-ml-1.2.82.tgz",
+      "integrity": "sha512-RrUmYrT+2RCZE+/Tv5urm05zJVG9vJb0zlQXfuvBhwRuBJ5UUFZr0CCPgLWyvMX01HcLbkBi+6dxo5rSUUi9RQ==",
       "requires": {
         "bespoken-jest-stare": "^1.0.20",
         "chalk": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bespoken-tools",
-  "version": "2.4.104",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Tools for making Alexa development easier and more fun",
   "license": "SEE LICENSE IN LICENSE",
   "private": false,
-  "version": "2.4.104",
+  "version": "2.5.2",
   "bin": {
     "bst": "./bin/bst.js",
     "bst-server": "./bin/bst-server.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "properties-reader": "0.0.15",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
-    "skill-testing-ml": "^1.2.81",
+    "skill-testing-ml": "^1.2.82",
     "update-notifier": "^2.5.0",
     "uuid": "3.0.0",
     "virtual-alexa": "^0.7.2",


### PR DESCRIPTION
- Update dependencies to use the beta version of skill-testing-ml@12.82. This version contains changes to support consolidated report