### PR TITLE
Removing node-zip dependency as it's not referenced in source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ site/
 !test/resources/exampleProject/*
 !test/resources/deployProject/*
 test/resources/ContentPromoPromptCopy.m4a
+
+.nvmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -6422,14 +6422,6 @@
         "verror": "1.10.0"
       }
     },
-    "jszip": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
-      "integrity": "sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=",
-      "requires": {
-        "pako": "~0.2.5"
-      }
-    },
     "just-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
@@ -7400,14 +7392,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
     },
-    "node-zip": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
-      "integrity": "sha1-lNGtZ0o81GoViN1zb0qaeMdX62I=",
-      "requires": {
-        "jszip": "2.5.0"
-      }
-    },
     "nomnom": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
@@ -7899,11 +7883,6 @@
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
       }
-    },
-    "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
     },
     "parse-filepath": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jest-html-reporters": "^1.1.0",
     "logless-client": "0.0.1",
     "nock": "^9.6.0",
-    "node-zip": "^1.1.1",
     "properties-reader": "0.0.15",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",


### PR DESCRIPTION
Removing node-zip dependency in order to fix the vulnerability reported in #677 

Apparently, the source code does not make use of that library it is better to remove it