### PR TITLE
FIX: Change the values of the files generated by bst init when type e2e and multi locale.

### DIFF
--- a/lib/init/init-util.ts
+++ b/lib/init/init-util.ts
@@ -15,7 +15,7 @@ export class InitUtil {
         private dialogFlow?: string,
         private testingExist?: boolean,
         private phoneNumber?: string,
-        ) {
+    ) {
         this.isMultilocale = locales.split(",").length > 1;
         this.projectName = projectName || "voice hello world";
         this.handler = handler || "index.js";
@@ -143,7 +143,7 @@ export class InitUtil {
         let expected = "";
         let input = "";
         if (this.isMultilocale) {
-            input = "LaunchRequest";
+            input = "invocationUtterance";
             expected = "launchPrompt";
         } else {
             if (type === "unit") {
@@ -190,7 +190,7 @@ export class InitUtil {
             if (type === "unit") {
                 input = platform === "alexa" ? "AMAZON.HelpIntent" : "HelpIntent";
             } else if (type === "e2e") {
-                input = "helpUtterance";
+                input = "$HELP_UTTERANCE";
             }
         } else {
             if (type === "unit") {
@@ -268,6 +268,9 @@ export class InitUtil {
             fs.mkdirSync(`${currentFolder}/test/${type}/locales`);
         }
 
+        const invocationUtterance = this.isMultilocale ? `Open ${this.projectName} overview` : undefined;
+        const $HELP_UTTERANCE = this.isMultilocale ? "help" : undefined;
+
         const localizedValues = {
             testSuiteDescription: "My first unit test suite",
             firstTestName: "Launch and ask for help",
@@ -275,6 +278,8 @@ export class InitUtil {
             helpPrompt: "What can I help you with?",
             helpCardContent: "What can I help you with?",
             helpCardTitle: this.projectName,
+            invocationUtterance,
+            $HELP_UTTERANCE
         };
         await Promise.all(this.locales.split(",").filter((x) => x).map((locale) => {
             locale = locale.trim();
@@ -309,5 +314,5 @@ export class InitUtil {
                 resolve();
             });
         });
-     }
+    }
 }

--- a/test/init/init-util-test.ts
+++ b/test/init/init-util-test.ts
@@ -1,8 +1,11 @@
 import * as assert from "assert";
-import {InitUtil} from "../../lib/init/init-util";
+import { InitUtil } from "../../lib/init/init-util";
 import * as fs from "fs";
+import { get } from "lodash";
+import { TestParser } from "skill-testing-ml";
+import { Global } from "../../lib/core/global";
 
-describe("init util", function() {
+describe("init util", function () {
     beforeEach(() => {
         if (!fs.existsSync("test/init/temp")) {
             fs.mkdirSync("test/init/temp");
@@ -98,9 +101,122 @@ describe("init util", function() {
         });
     });
 
+    describe("init with multi locale and e2e", () => {
+        it("Should create only invocationUtterance and helpUtterance", async () => {
+            const locales = ["en-US", "es-PE"];
+            const projectName = "hello world";
+            await new InitUtil("e2e", "alexa", "index.js", locales.join(","), projectName, undefined, undefined, false).createFiles();
+
+            const existUnitTestFile = "test/unit/index.test.yml";
+            const existE2eTestFile = "test/e2e/index.e2e.yml";
+            const existTestingFile = "testing.json";
+
+
+            assert.ok(!fs.existsSync(existUnitTestFile));
+            assert.ok(fs.existsSync(existE2eTestFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            assert.ok(fs.existsSync(existTestingFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            // validate files were create
+            assert.ok(locales.map(f => fs.existsSync(`test/e2e/locales/${f}.yml`)).filter(v => v === false).length === 0);
+
+            await Global.loadConfig();
+            const parser: TestParser = new TestParser("test/e2e/index.e2e.yml");
+            const testSuite = parser.parse({});
+            await testSuite.loadLocalizedValues();
+
+            assert.deepStrictEqual(testSuite.tests.map(t => t.interactions).reduce((p, c) => p.concat(c), []).map(v => get(v, "utterance")), ["invocationUtterance", "$HELP_UTTERANCE"]);
+        });
+
+        it("Should create only invocationUtterance and helpUtterance in locales", async () => {
+            const locales = ["en-US", "es-PE"];
+            const projectName = "hello world";
+            await new InitUtil("e2e", "alexa", "index.js", locales.join(","), projectName, undefined, undefined, false).createFiles();
+
+            const existUnitTestFile = "test/unit/index.test.yml";
+            const existE2eTestFile = "test/e2e/index.e2e.yml";
+            const existTestingFile = "testing.json";
+
+
+            assert.ok(!fs.existsSync(existUnitTestFile));
+            assert.ok(fs.existsSync(existE2eTestFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            assert.ok(fs.existsSync(existTestingFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            // validate files were create
+            assert.ok(locales.map(f => fs.existsSync(`test/e2e/locales/${f}.yml`)).filter(v => v === false).length === 0);
+
+            await Global.loadConfig();
+            const parser: TestParser = new TestParser("test/e2e/index.e2e.yml");
+            const testSuite = parser.parse({});
+            await testSuite.loadLocalizedValues();
+
+            assert.deepStrictEqual(get(testSuite, `localizedValues[${locales[0]}].invocationUtterance`, null), `Open ${projectName} overview`);
+            assert.deepStrictEqual(get(testSuite, `localizedValues[${locales[0]}].$HELP_UTTERANCE`, null), "help");
+        });
+
+        it("Should not create locale files if only one locale", async () => {
+            const locales = ["en-US"];
+            const projectName = "hello world";
+            await new InitUtil("e2e", "alexa", "index.js", locales.join(","), projectName, undefined, undefined, false).createFiles();
+
+            const existUnitTestFile = "test/unit/index.test.yml";
+            const existE2eTestFile = "test/e2e/index.e2e.yml";
+            const existTestingFile = "testing.json";
+
+
+            assert.ok(!fs.existsSync(existUnitTestFile));
+            assert.ok(fs.existsSync(existE2eTestFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            assert.ok(fs.existsSync(existTestingFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            // validate files were create
+            assert.ok(locales.map(f => fs.existsSync(`test/e2e/locales/${f}.yml`)).filter(v => v === true).length === 0);
+            await Global.loadConfig();
+            const parser: TestParser = new TestParser("test/e2e/index.e2e.yml");
+            const testSuite = parser.parse({});
+            await testSuite.loadLocalizedValues();
+
+            assert.deepStrictEqual(testSuite.tests.map(t => t.interactions).reduce((p, c) => p.concat(c), []).map(v => get(v, "utterance")), [`open ${projectName}`, "help"]);
+        });
+
+        it("Should not create invocationUtterance and helpUtterance in locales if only one locale", async () => {
+            const locales = ["en-US"];
+            await new InitUtil("e2e", "alexa", "index.js", locales.join(","), "hello world", undefined, undefined, false).createFiles();
+
+            const existUnitTestFile = "test/unit/index.test.yml";
+            const existE2eTestFile = "test/e2e/index.e2e.yml";
+            const existTestingFile = "testing.json";
+
+
+            assert.ok(!fs.existsSync(existUnitTestFile));
+            assert.ok(fs.existsSync(existE2eTestFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            assert.ok(fs.existsSync(existTestingFile));
+            assert.ok(fs.existsSync(existTestingFile));
+
+            // validate files were create
+            assert.ok(locales.map(f => fs.existsSync(`test/e2e/locales/${f}.yml`)).filter(v => v === true).length === 0);
+            await Global.loadConfig();
+            const parser: TestParser = new TestParser("test/e2e/index.e2e.yml");
+            const testSuite = parser.parse({});
+            await testSuite.loadLocalizedValues();
+
+            assert.deepStrictEqual(get(testSuite, `localizedValues[${locales[0]}].invocationUtterance`, null), null);
+            assert.deepStrictEqual(get(testSuite, `localizedValues[${locales[0]}].helpUtterance`, null), null);
+        });
+    });
+
     function deleteFolderRecursive(path: string) {
         if (fs.existsSync(path)) {
-            fs.readdirSync(path).forEach(function(file, index) {
+            fs.readdirSync(path).forEach(function (file, index) {
                 const curPath = path + "/" + file;
                 if (fs.lstatSync(curPath).isDirectory()) { // recurse
                     deleteFolderRecursive(curPath);


### PR DESCRIPTION
Only when the type is e2e and it is a multi-locale project the project created should be created with the following file:

**index.e2e.yml**

```
---
configuration:
  description: testSuiteDescription
---
- test : firstTestName
- invocationUtterance : "launchPrompt"
- $HELP_UTTERANCE : "helpPrompt"
```
**en-US.yml**
```
testSuiteDescription: My first unit test suite
firstTestName: Launch and ask for help
launchPrompt: Welcome to voice hello world
helpPrompt: What can I help you with?
helpCardContent: What can I help you with?
helpCardTitle: voice hello world
invocationUtterance: Open voice hello world overview
$HELP_UTTERANCE: help
```